### PR TITLE
✨  Various config improvements

### DIFF
--- a/images/build/go-1.24/env
+++ b/images/build/go-1.24/env
@@ -1,7 +1,7 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.24.1-1
+BUILD_IMAGE_TAG=1.24.2-1
 # the Go version used for the images.
-GO_VERSION=1.24.1
+GO_VERSION=1.24.2
 # the kindest image that matches the kind version above
 KINDEST_IMAGE=kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -87,7 +87,7 @@ github_reporter:
 
 tide:
   pr_status_base_urls:
-    "*": https://prow2-private.kubestellar.io/pr
+    "*": https://prow2-private.kubestellar.io/
 
   merge_method:
     kubestellar: merge

--- a/prow/jobs/kcp-dev/client-go/client-go-presubmits.yaml
+++ b/prow/jobs/kcp-dev/client-go/client-go-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
           clone_uri: git@github.com:kubestellar/infra.git
       spec:
         containers:
-          - image: gcr.io/k8s-prow/checkconfig:v20230919-a4926a4d02
+          - image: gcr.io/k8s-prow/checkconfig:v20240802-66b115076
             command:
               - checkconfig
             args:

--- a/prow/jobs/kcp-dev/code-generator/code-generator-presubmits.yaml
+++ b/prow/jobs/kcp-dev/code-generator/code-generator-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
           clone_uri: git@github.com:kubestellar/infra.git
       spec:
         containers:
-          - image: gcr.io/k8s-prow/checkconfig:v20230919-a4926a4d02
+          - image: gcr.io/k8s-prow/checkconfig:v20240802-66b115076
             command:
               - checkconfig
             args:

--- a/prow/jobs/kcp-dev/helm-charts/helm-charts-presubmits.yaml
+++ b/prow/jobs/kcp-dev/helm-charts/helm-charts-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
           clone_uri: git@github.com:kubestellar/infra.git
       spec:
         containers:
-          - image: gcr.io/k8s-prow/checkconfig:v20230919-a4926a4d02
+          - image: gcr.io/k8s-prow/checkconfig:v20240802-66b115076
             command:
               - checkconfig
             args:

--- a/prow/jobs/kcp-dev/infra/infra-presubmits.yaml
+++ b/prow/jobs/kcp-dev/infra/infra-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
       clone_uri: "ssh://git@github.com/kubestellar/infra.git"
       spec:
         containers:
-          - image: gcr.io/k8s-prow/checkconfig:v20230919-a4926a4d02
+          - image: gcr.io/k8s-prow/checkconfig:v20240802-66b115076
             command:
               - checkconfig
             args:
@@ -23,7 +23,7 @@ presubmits:
         - ^main$
       spec:
         containers:
-          - image: gcr.io/k8s-prow/checkconfig:v20230919-a4926a4d02
+          - image: gcr.io/k8s-prow/checkconfig:v20240802-66b115076
             command:
               - checkconfig
             args:

--- a/prow/jobs/kcp-dev/kcp-dev.github.io/kcp-dev.github.io-presubmits.yaml
+++ b/prow/jobs/kcp-dev/kcp-dev.github.io/kcp-dev.github.io-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
           clone_uri: git@github.com:kubestellar/infra.git
       spec:
         containers:
-          - image: gcr.io/k8s-prow/checkconfig:v20230919-a4926a4d02
+          - image: gcr.io/k8s-prow/checkconfig:v20240802-66b115076
             command:
               - checkconfig
             args:

--- a/prow/jobs/kcp-dev/kcp.io/kcp.io-presubmits.yaml
+++ b/prow/jobs/kcp-dev/kcp.io/kcp.io-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
           clone_uri: git@github.com:kubestellar/infra.git
       spec:
         containers:
-          - image: gcr.io/k8s-prow/checkconfig:v20230919-a4926a4d02
+          - image: gcr.io/k8s-prow/checkconfig:v20240802-66b115076
             command:
               - checkconfig
             args:

--- a/prow/jobs/kcp-dev/kcp/kcp-presubmits.yaml
+++ b/prow/jobs/kcp-dev/kcp/kcp-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
           clone_uri: git@github.com:kubestellar/infra.git
       spec:
         containers:
-          - image: gcr.io/k8s-prow/checkconfig:v20230919-a4926a4d02
+          - image: gcr.io/k8s-prow/checkconfig:v20240802-66b115076
             command:
               - checkconfig
             args:

--- a/prow/jobs/kubestellar/kubestellar/kubestellar-presubmits.yaml
+++ b/prow/jobs/kubestellar/kubestellar/kubestellar-presubmits.yaml
@@ -2,6 +2,7 @@ presubmits:
   kubestellar/kubestellar:
     - name: pull-kubestellar-kubestellar-validate-prow-yaml
       always_run: true
+      optional: true
       decorate: true
       clone_uri: "ssh://git@github.com/kubestellar/kubestellar.git"
       extra_refs:

--- a/prow/jobs/kubestellar/kubestellar/kubestellar-presubmits.yaml
+++ b/prow/jobs/kubestellar/kubestellar/kubestellar-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
           clone_uri: git@github.com:kubestellar/infra.git
       spec:
         containers:
-          - image: gcr.io/k8s-prow/checkconfig:v20230919-a4926a4d02
+          - image: gcr.io/k8s-prow/checkconfig:v20240802-66b115076
             command:
               - checkconfig
             args:


### PR DESCRIPTION
This PR does multiple things:
- bumps the go 1.24 builder release to 1.24.2;
- trims the bogus `/pr` from the tail of `tide.pr_status_base_urls`;
- updates the prow version in the prow job defns to match what is running in the cluster;
- Make the pull-kubestellar-kubestellar-validate-prow-yaml test optional.

I do not understand what sort of "match" is being discussed in https://github.com/kubestellar/infra/blob/8bcddbd04571b9ab38f8433be7aada7c9c617cac/images/build/go-1.24/env#L6 , so did not change the KINDEST_IMAGE.