### PR TITLE
✨  Spec builder for go-1.24.3

### DIFF
--- a/images/build/go-1.24/env
+++ b/images/build/go-1.24/env
@@ -1,7 +1,7 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.24.2-1
+BUILD_IMAGE_TAG=1.24.3-1
 # the Go version used for the images.
-GO_VERSION=1.24.2
+GO_VERSION=1.24.3
 # the kindest image that matches the kind version above
 KINDEST_IMAGE=kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f


### PR DESCRIPTION
This PR updates the spec for the go-1.24 builder to patch release 3.