### PR TITLE
Add A2A repository configuration and update related settings

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -202,7 +202,7 @@ branch-protection:
           restrictions:
             users: []
             teams:
-              - kubestellar/a2a-admins
+              - kubestellar/kubestellar-a2a-maintainers
           include:
             - "^main$"
             - "^release-.+$"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -11,12 +11,14 @@ plank:
     "kubestellar/kubestellar": "[Full PR test history](https://prow2.kubestellar.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})"
     "kubestellar/ui": "[Full PR test history](https://prow2.kubestellar.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})"
     "kubestellar/kubeflex": "[Full PR test history](https://prow2.kubestellar.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})"
+    "kubestellar/a2a": "[Full PR test history](https://prow2.kubestellar.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})"
 
   job_url_prefix_config:
     "*": https://prow2-private.kubestellar.io/view/
     "kubestellar/kubestellar": "https://prow2.kubestellar.io/view/"
     "kubestellar/ui": "https://prow2.kubestellar.io/view/"
     "kubestellar/kubeflex": "https://prow2.kubestellar.io/view/"
+    "kubestellar/a2a": "https://prow2.kubestellar.io/view/"
 
   default_decoration_config_entries:
     - config:
@@ -98,7 +100,8 @@ tide:
     kubestellar/kubestellar: merge 
     kubestellar/ui: squash
     kubestellar/kubeflex: merge 
-    kubestellar/infra: merge 
+    kubestellar/infra: merge
+    kubestellar/a2a: squash 
   queries:
     # no release notes
     - repos:
@@ -118,6 +121,18 @@ tide:
     # Query for UI repo without DCO requirement
     - repos:
         - kubestellar/ui
+      labels:
+        - lgtm
+        - approved
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    # Query for A2A repo without DCO requirement
+    - repos:
+        - kubestellar/a2a
       labels:
         - lgtm
         - approved
@@ -177,6 +192,17 @@ branch-protection:
             users: []
             teams:
               - kubestellar/kubestellar-admins
+          include:
+            - "^main$"
+            - "^release-.+$"
+        a2a:  # Added A2A without DCO check
+          protect: true
+          required_status_checks:
+            contexts: []
+          restrictions:
+            users: []
+            teams:
+              - kubestellar/a2a-admins
           include:
             - "^main$"
             - "^release-.+$"

--- a/prow/jobs/kubestellar/a2a/a2a-presubmits.yaml
+++ b/prow/jobs/kubestellar/a2a/a2a-presubmits.yaml
@@ -1,0 +1,106 @@
+presubmits:
+  kubestellar/a2a:
+    - name: pull-kubestellar-a2a-validate-prow-yaml
+      always_run: true
+      optional: true
+      decorate: true
+      clone_uri: "ssh://git@github.com/kubestellar/a2a.git"
+      extra_refs:
+        - org: kubestellar
+          repo: infra
+          base_ref: main
+          clone_uri: git@github.com:kubestellar/infra.git
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20240802-66b115076
+            command:
+              - checkconfig
+            args:
+              - -plugin-config=/home/prow/go/src/github.com/kubestellar/infra/prow/plugins.yaml
+              - -config-path=/home/prow/go/src/github.com/kubestellar/infra/prow/config.yaml
+              - -job-config-path=/home/prow/go/src/github.com/kubestellar/infra/prow/jobs
+              - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)
+
+    - name: pull-kubestellar-a2a-verify
+      always_run: true
+      decorate: true
+      clone_uri: 'https://github.com/kubestellar/a2a'
+      spec:
+        containers:
+          - image: python:3.11
+            command:
+              - /bin/bash
+              - -c
+              - |
+                # Install uv package manager
+                curl -LsSf https://astral.sh/uv/install.sh | sh
+                export PATH="/root/.cargo/bin:$PATH"
+                
+                # Install dependencies
+                uv sync --dev
+                
+                # Run tests with pytest and coverage
+                uv run pytest tests/ -v --cov=src/ --cov-report=xml --cov-report=term
+            resources:
+              requests:
+                memory: 2Gi
+                cpu: 1
+
+    - name: pull-kubestellar-a2a-verify-py312
+      always_run: true
+      decorate: true
+      clone_uri: 'https://github.com/kubestellar/a2a'
+      spec:
+        containers:
+          - image: python:3.12
+            command:
+              - /bin/bash
+              - -c
+              - |
+                # Install uv package manager
+                curl -LsSf https://astral.sh/uv/install.sh | sh
+                export PATH="/root/.cargo/bin:$PATH"
+                
+                # Install dependencies
+                uv sync --dev
+                
+                # Run tests with pytest and coverage
+                uv run pytest tests/ -v --cov=src/ --cov-report=xml --cov-report=term
+            resources:
+              requests:
+                memory: 2Gi
+                cpu: 1
+
+    - name: pull-kubestellar-a2a-lint
+      always_run: true
+      decorate: true
+      clone_uri: 'https://github.com/kubestellar/a2a'
+      spec:
+        containers:
+          - image: python:3.11
+            command:
+              - /bin/bash
+              - -c
+              - |
+                # Install uv package manager
+                curl -LsSf https://astral.sh/uv/install.sh | sh
+                export PATH="/root/.cargo/bin:$PATH"
+                
+                # Install dependencies
+                uv sync --dev
+                
+                # Lint with ruff
+                echo "Running ruff..."
+                uv run ruff check src/ tests/ --fix
+                
+                # Check formatting with black
+                echo "Checking formatting with black..."
+                uv run black src/ tests/ --check --diff
+                
+                # Type check with mypy (non-blocking)
+                echo "Type checking with mypy..."
+                uv run mypy src/ --ignore-missing-imports || echo "Type checking issues found (non-blocking)"
+            resources:
+              requests:
+                memory: 1Gi
+                cpu: 500m

--- a/prow/jobs/kubestellar/infra/infra-periodics.yaml
+++ b/prow/jobs/kubestellar/infra/infra-periodics.yaml
@@ -19,7 +19,7 @@ periodics:
         args:
         - --config=/home/prow/go/src/github.com/kubestellar/infra/prow/labels.yaml
         - --confirm=true
-        - --only=kubestellar/kubestellar,kubestellar/kubeflex,kubestellar/ui,kubestellar/infra
+        - --only=kubestellar/kubestellar,kubestellar/kubeflex,kubestellar/ui,kubestellar/infra,kubestellar/a2a
         - --token=/etc/oauth-token/token
         - --endpoint=http://ghproxy.prow.svc.cluster.local
         - --endpoint=https://api.github.com

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -9,6 +9,7 @@ triggers:
       - kubestellar/ui
       - kubestellar/kubeflex
       - kubestellar/infra
+      - kubestellar/a2a
     only_org_members: true
 
 approve:
@@ -17,6 +18,7 @@ approve:
       - kubestellar/ui
       - kubestellar/kubeflex
       - kubestellar/infra
+      - kubestellar/a2a
     ignore_review_state: true
     require_self_approval: true
 
@@ -26,6 +28,7 @@ lgtm:
       - kubestellar/ui
       - kubestellar/kubeflex
       - kubestellar/infra
+      - kubestellar/a2a
     # adds lgtm if GitHub review state is "Approve"
     # and removes lgtm if review state is "Request Changes"
     review_acts_as_lgtm: true
@@ -131,6 +134,24 @@ plugins:
       - trigger
       - verify-owners
       - wip
+  kubestellar/a2a:  # A2A repository configuration without DCO
+    plugins:
+      - approve
+      - assign
+      - branchcleaner
+      - hold
+      - label
+      - lgtm
+      - lifecycle
+      - milestoneapplier
+      - override
+      - owners-label
+      - retitle
+      - size
+      - skip
+      - trigger
+      - verify-owners
+      - wip
   kubestellar/infra:
     plugins:
       - config-updater
@@ -160,6 +181,14 @@ external_plugins:
         - issue_comment
         - pull_request
   kubestellar/kubeflex:
+    - name: needs-rebase
+      events:
+        - pull_request
+    - name: cherrypicker
+      events:
+        - issue_comment
+        - pull_request
+  kubestellar/a2a:
     - name: needs-rebase
       events:
         - pull_request


### PR DESCRIPTION
Introduce A2A repository settings in the configuration files, including presubmit jobs for validation and verification, and update the label sync job to include A2A. Enhance the plugin repository whitelist to accommodate A2A plugins.

Fixes #21