### PR TITLE
fix: switch Prow clone_uri to HTTPS to resolve permission error 

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,7 +1,7 @@
 presubmits:
   - name: pull-infra-images-1.23-build
     decorate: true
-    clone_uri: "ssh://git@github.com/kubestellar/infra.git"
+    clone_uri: "https://github.com/kubestellar/infra.git"
     run_if_changed: '^images/build/go-1.23'
     labels:
       preset-goproxy: "true"
@@ -24,7 +24,7 @@ presubmits:
 
   - name: pull-infra-images-1.24-build
     decorate: true
-    clone_uri: "ssh://git@github.com/kubestellar/infra.git"
+    clone_uri: "https://github.com/kubestellar/infra.git"
     run_if_changed: '^images/build/go-1.24'
     labels:
       preset-goproxy: "true"
@@ -44,3 +44,4 @@ presubmits:
             requests:
               memory: 1Gi
               cpu: 1
+              

--- a/prow/jobs/kubestellar/infra/infra-postsubmits.yaml
+++ b/prow/jobs/kubestellar/infra/infra-postsubmits.yaml
@@ -5,7 +5,7 @@ postsubmits:
       run_if_changed: "clusters/prow/"
       decorate: true
       cluster: prow
-      clone_uri: "ssh://git@github.com/kubestellar/infra.git"
+      clone_uri: "https://github.com/kubestellar/infra.git"
       labels:
         preset-prow-kubeconfig: "true"
       branches:
@@ -26,7 +26,7 @@ postsubmits:
       run_if_changed: "clusters/build/"
       decorate: true
       cluster: prow
-      clone_uri: "ssh://git@github.com/kubestellar/infra.git"
+      clone_uri: "https://github.com/kubestellar/infra.git"
       labels:
         preset-prow-kubeconfig: "true"
       branches:
@@ -44,7 +44,7 @@ postsubmits:
 
     - name: post-infra-publish-images-1.23-build
       decorate: true
-      clone_uri: "ssh://git@github.com/kubestellar/infra.git"
+      clone_uri: "https://github.com/kubestellar/infra.git"
       cluster: prow # GHCR credentials are only available here
       labels:
         preset-ghcr-credentials: "true"
@@ -67,7 +67,7 @@ postsubmits:
 
     - name: post-infra-publish-images-1.24-build
       decorate: true
-      clone_uri: "ssh://git@github.com/kubestellar/infra.git"
+      clone_uri: "https://github.com/kubestellar/infra.git"
       cluster: prow # GHCR credentials are only available here
       labels:
         preset-ghcr-credentials: "true"
@@ -87,3 +87,4 @@ postsubmits:
               requests:
                 cpu: 2
                 memory: 3Gi
+                


### PR DESCRIPTION
Fixes kubestellar/kubestellar#3552

**Description**
This PR updates the Prow configuration to use HTTPS cloning (`https://github.com/...`) instead of SSH. This resolves the `Permission denied (publickey)` error caused by missing SSH secrets in the CI environment.

This implements the solution suggested by @elskow in the issue discussion.

**Changes**
- Updated `clone_uri` in `.prow.yaml` to use HTTPS.
- Updated `clone_uri` in `prow/jobs/kubestellar/infra/infra-postsubmits.yaml` to use HTTPS.