### PR TITLE
fix: resolve broken spyglass build log links

### DIFF
--- a/clusters/prow/manifests/prow/01-gcsweb-public.yaml
+++ b/clusters/prow/manifests/prow/01-gcsweb-public.yaml
@@ -76,7 +76,7 @@ metadata:
     ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
   rules:
-    - host: 'public-gcsweb.kcp.k8c.io'
+    - host: 'gcsweb.kubestellar.io'
       http:
         paths:
           - path: /
@@ -88,5 +88,6 @@ spec:
                   number: 80
   tls:
     - hosts:
-        - 'public-gcsweb.kcp.k8c.io'
+        - 'gcsweb.kubestellar.io'
       secretName: gcsweb-public-tls
+      

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -63,7 +63,7 @@ sinker:
 
 deck:
   spyglass:
-    gcs_browser_prefix: "http://minio.prow.svc.cluster.local:9000/prow-logs/"
+    gcs_browser_prefix: "https://gcsweb.kubestellar.io/prow-logs/"
     lenses:
       - required_files:
           - ^(?:started|finished)\.json$
@@ -299,4 +299,4 @@ periodics:
   #           - --config-path=/home/prow/go/src/github.com/kubestellar/kubestellar/prow/config.yaml
   #           - --plugin-config=/home/prow/go/src/github.com/kubestellar/kubestellar/prow/plugins.yaml
   #           - --label-config=/home/prow/go/src/github.com/kubestellar/kubestellar/prow/labels.yaml
-  #           - --job-config-path=/home/prow/go/src/github.com/kubestellar/kubestellar/prow/jobs          
+  #           - --job-config-path=/home/prow/go/src/github.com/kubestellar/kubestellar/prow/jobs


### PR DESCRIPTION
Fixes #3551

**Summary:**
The `gcs_browser_prefix` was pointing to an internal cluster DNS, and the GCSWeb Ingress was pointing to a legacy KCP domain (`kcp.k8c.io`).

**Changes:**
* Updated `prow/config.yaml` to point to the public `gcsweb` URL (`gcsweb.kubestellar.io`) instead of the internal MinIO service.
* Updated `01-gcsweb-public.yaml` Ingress to use `gcsweb.kubestellar.io`.