### PR TITLE
Expand label sync to all repos and add KubeStellar-specific labels

### DIFF
--- a/prow/jobs/kubestellar/infra/infra-periodics.yaml
+++ b/prow/jobs/kubestellar/infra/infra-periodics.yaml
@@ -19,7 +19,7 @@ periodics:
         args:
         - --config=/home/prow/go/src/github.com/kubestellar/infra/prow/labels.yaml
         - --confirm=true
-        - --only=kubestellar/kubestellar,kubestellar/kubeflex,kubestellar/ui,kubestellar/infra,kubestellar/a2a
+        - --only=kubestellar/kubestellar,kubestellar/kubeflex,kubestellar/ui,kubestellar/infra,kubestellar/a2a,kubestellar/docs,kubestellar/community,kubestellar/helm,kubestellar/kubectl-multi-plugin,kubestellar/kubectl-rbac-flatten-plugin,kubestellar/galaxy,kubestellar/core,kubestellar/ocm-status-addon,kubestellar/repo-template-go,kubestellar/ui-plugins,kubestellar/kubestellar-killercoda,kubestellar/kubestellar-infrastructure
         - --token=/etc/oauth-token/token
         - --endpoint=http://ghproxy.prow.svc.cluster.local
         - --endpoint=https://api.github.com

--- a/prow/labels.yaml
+++ b/prow/labels.yaml
@@ -396,3 +396,223 @@ default:
       target: both
       prowPlugin: shrug
       addedBy: humans
+
+orgs:
+  kubestellar:
+    labels:
+      # KubeStellar-specific kind/bug color (blue instead of red)
+      - color: 22A0DF
+        description: Categorizes issue or PR as related to a bug.
+        name: kind/bug
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      # KubeStellar-specific priority labels
+      - color: e11d21
+        description: Highest priority. Must be actively worked on as someone's top priority right now.
+        name: priority/high
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: eb6420
+        description: Must be staffed and worked on either currently, or very soon, ideally in time for the next release.
+        name: priority/medium
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: fbca04
+        description: Higher priority than priority/awaiting-more-evidence.
+        name: priority/low
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: fef2c0
+        description: Lowest priority. Possibly useful, but not yet enough support to actually get it done.
+        name: priority/awaiting
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      # KubeStellar area labels
+      - color: 80FD11
+        description: Issues or PRs related to Edge-specific workspaces
+        name: area/workspace
+        target: both
+        addedBy: label
+      - color: 80FD11
+        description: Issues or PRs related to edge workspace
+        name: area/scheduler
+        target: both
+        addedBy: label
+      - color: 80FD11
+        description: Issues or PRs related to Edge-specific placement
+        name: area/placement
+        target: both
+        addedBy: label
+      - color: 80fd11
+        description: Issues or PRs related to policy distribution
+        name: area/policy
+        target: both
+        addedBy: label
+      - color: 80FD11
+        description: For items related to syncer and kcp-edge-specific enhancements required to it
+        name: area/syncer
+        target: both
+        addedBy: label
+      - color: 0052cc
+        description: Issues or PRs related to Kubernetes licensing
+        name: area/licensing
+        target: both
+        addedBy: label
+      # KubeStellar project management labels
+      - color: 5C253A
+        description: Epic tracking issue
+        name: Epic
+        target: issues
+        addedBy: humans
+      - color: FCF42D
+        description: Issues related to community meetings
+        name: community-meeting
+        target: issues
+        addedBy: humans
+      - color: BB3A42
+        description: Initialization related
+        name: init
+        target: both
+        addedBy: humans
+      - color: 15dd18
+        description: Indicates a release branch PR has been approved by a staff engineer.
+        name: staff-eng-approved
+        target: prs
+        addedBy: humans
+      - color: 15dd18
+        description: Indicates that all commits come from merged upstream PRs.
+        name: backports/validated-commits
+        target: prs
+        addedBy: humans
+      - color: e11d21
+        description: Indicates that not all commits come from merged upstream PRs.
+        name: backports/unvalidated-commits
+        target: prs
+        addedBy: humans
+      - color: fef2c0
+        description: Indicates a PR to a release branch has been evaluated and considered safe to accept.
+        name: backport-risk-assessed
+        target: prs
+        addedBy: humans
+      - color: bfdadc
+        description: Touching vendor dir or related files
+        name: vendor-update
+        target: both
+        addedBy: humans
+      # KubeStellar feature labels
+      - color: 7057ff
+        description: Denotes an issue ready for a new contributor, according to the "help wanted" guidelines.
+        name: first-timers-only
+        target: issues
+        addedBy: humans
+      - color: 0366d6
+        description: Pull requests that update a dependency file
+        name: dependencies
+        target: prs
+        addedBy: prow
+      - color: B5E863
+        description: Issues related to preparation for a conference
+        name: conference
+        target: issues
+        addedBy: humans
+      - color: B33DF2
+        description: Issues that are related to installing and running the quickstart example
+        name: quickstart
+        target: both
+        addedBy: humans
+      - color: d93f0b
+        description: Issues or PRs related to the low-level API machinery for KubeStellar
+        name: backend
+        target: both
+        addedBy: humans
+      - color: 081C43
+        description: Partner related issues
+        name: partner
+        target: issues
+        addedBy: humans
+      - color: C0E896
+        description: Issues or PRs related to creating blog postings for KubeStellar
+        name: blog
+        target: both
+        addedBy: humans
+      # KubeStellar triage/workflow labels
+      - color: d455d0
+        description: Indicates an issue that is a support question.
+        name: triage/support
+        target: both
+        addedBy: humans
+      - color: DD5AFE
+        description: Question about whether this issue is still valid
+        name: is this still valid?
+        target: issues
+        addedBy: humans
+      - color: CB13CB
+        description: Related to space framework
+        name: space framework
+        target: both
+        addedBy: humans
+      - color: DF1C6C
+        description: Architecture discussion needed
+        name: architecture discussion
+        target: issues
+        addedBy: humans
+      - color: CC374E
+        description: MCC related
+        name: MCC
+        target: both
+        addedBy: humans
+      - color: 7060B5
+        description: Troubleshooting issues
+        name: troubleshooting
+        target: issues
+        addedBy: humans
+      - color: 05A5A5
+        description: Edge deployment related
+        name: edgeDeployment
+        target: both
+        addedBy: humans
+      - color: C55745
+        description: Pluggable transport related
+        name: pluggable-transport
+        target: both
+        addedBy: humans
+      - color: 1F89F9
+        description: User experience related
+        name: ux
+        target: both
+        addedBy: humans
+      - color: D93F0B
+        description: Phase 0 related
+        name: phase0
+        target: both
+        addedBy: humans
+      - color: 82FCBE
+        description: Main legacy related
+        name: main-legacy
+        target: both
+        addedBy: humans
+      - color: fbca04
+        description: Backlog item
+        name: backlog
+        target: both
+        addedBy: humans
+      - color: 1A26C9
+        description: This feature is required for UC1 validation
+        name: uc1-validation
+        target: both
+        addedBy: humans
+      - color: 0e8a16
+        description: MCAD integration related
+        name: MCAD integration
+        target: both
+        addedBy: humans
+      - color: E322F9
+        description: Switch to PT
+        name: switch to PT
+        target: both
+        addedBy: humans


### PR DESCRIPTION
## Summary
- Update `ci-infra-prow-labelsync` periodic job to sync labels to all 17 active repos (previously only synced to 5 repos)
- Add KubeStellar-specific labels to `labels.yaml` to match kubestellar/kubestellar repo

## Changes

### Repos added to label sync:
- kubestellar/docs
- kubestellar/community
- kubestellar/helm
- kubestellar/kubectl-multi-plugin
- kubestellar/kubectl-rbac-flatten-plugin
- kubestellar/galaxy
- kubestellar/core
- kubestellar/ocm-status-addon
- kubestellar/repo-template-go
- kubestellar/ui-plugins
- kubestellar/kubestellar-killercoda
- kubestellar/kubestellar-infrastructure

### Labels added:
- **Priority**: high, medium, low, awaiting
- **Area**: workspace, scheduler, placement, policy, syncer, licensing
- **Project**: Epic, community-meeting, init, staff-eng-approved, backports/*
- **Feature**: quickstart, backend, blog, conference, dependencies, first-timers-only
- **Workflow**: triage/support, backlog, ux, troubleshooting, and more

## Test plan
- [ ] Merge PR and wait for next hourly label sync run
- [ ] Verify labels are created/updated in target repos
- [ ] Check prow logs for `ci-infra-prow-labelsync` job success

🤖 Generated with [Claude Code](https://claude.com/claude-code)