### PR TITLE
fix: remove duplicate kind/bug label from kubestellar org section

### DIFF
--- a/prow/labels.yaml
+++ b/prow/labels.yaml
@@ -400,13 +400,6 @@ default:
 orgs:
   kubestellar:
     labels:
-      # KubeStellar-specific kind/bug color (blue instead of red)
-      - color: 22A0DF
-        description: Categorizes issue or PR as related to a bug.
-        name: kind/bug
-        target: both
-        prowPlugin: label
-        addedBy: anyone
       # KubeStellar-specific priority labels
       - color: e11d21
         description: Highest priority. Must be actively worked on as someone's top priority right now.


### PR DESCRIPTION
## Summary
- Remove duplicate `kind/bug` label from kubestellar org section in labels.yaml

## Problem
The `label_sync` job fails with error:
```
duplicate label kind/bug at kubestellar.kind/bug and default.kind/bug
```

The label is defined in both the `default` section and the `kubestellar` org section. The label_sync tool doesn't support overrides - it treats duplicates as errors.

## Changes
Remove the `kind/bug` entry from the kubestellar org section. The label will still exist (from the default section) but will use the default red color instead of blue.

## Test plan
- [ ] Verify label_sync job runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)