### PR TITLE
fix: use GitHub App auth for label_sync job

### DIFF
--- a/prow/jobs/kubestellar/infra/infra-periodics.yaml
+++ b/prow/jobs/kubestellar/infra/infra-periodics.yaml
@@ -20,15 +20,16 @@ periodics:
         - --config=/home/prow/go/src/github.com/kubestellar/infra/prow/labels.yaml
         - --confirm=true
         - --orgs=kubestellar
-        - --token=/etc/oauth-token/token
+        - --github-app-id=1227751
+        - --github-app-private-key-path=/etc/github-app/cert
         - --endpoint=http://ghproxy.prow.svc.cluster.local
         - --endpoint=https://api.github.com
         - --debug
         volumeMounts:
-        - name: oauth-token
-          mountPath: /etc/oauth-token
+        - name: github-app
+          mountPath: /etc/github-app
           readOnly: true
       volumes:
-      - name: oauth-token
+      - name: github-app
         secret:
           secretName: github-token


### PR DESCRIPTION
## Summary
- Switch label_sync job from OAuth token to GitHub App authentication

## Problem
The label_sync job was configured to use `--token` but the `github-token` secret contains a GitHub App private key (`cert`), not an OAuth token. This caused the error:
```
net/http: invalid header field value for "Authorization"
```

## Changes
- Replace `--token=/etc/oauth-token/token` with GitHub App args:
  - `--github-app-id=1227751`
  - `--github-app-private-key-path=/etc/github-app/cert`
- Update volume mount to use `cert` key from the secret

## Test plan
- [ ] Merge and verify label_sync job runs successfully at :17 past the hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)