### PR TITLE
Reduce max_prowjob_age from 28 days to 7 days

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -56,10 +56,9 @@ sinker:
   resync_period: 1m
   # How long build pods are kept after finishing, defaults to 24h
   max_pod_age: 2h
-  # How long to keep ProwJob CRs, default is one week,
-  # we increase it to 28 days and have a jobarchiver CronJob that
-  # will move jobs older than 21d to another namespace.
-  max_prowjob_age: 672h
+  # How long to keep ProwJob CRs - reduced from 28 days to 7 days
+  # to improve PR dashboard loading performance
+  max_prowjob_age: 168h
 
 deck:
   spyglass:


### PR DESCRIPTION
## Summary
- Reduces ProwJob retention from 672h (28 days) to 168h (7 days)

## Motivation
The PR dashboard was slow due to loading ~1200 ProwJobs. This change will reduce the number of stored jobs and improve page load times.

## Test plan
- [ ] Verify sinker cleans up old jobs
- [ ] Verify dashboard loads faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)