### PR TITLE
Fix labelsync job: use default cluster and HTTPS clone

### DIFF
--- a/prow/jobs/kubestellar/infra/infra-periodics.yaml
+++ b/prow/jobs/kubestellar/infra/infra-periodics.yaml
@@ -2,7 +2,7 @@
 periodics:
   - name: ci-infra-prow-labelsync
     cron: "17 * * * *" # Every hour at 17 minutes past the hour
-    cluster: prow
+    cluster: default
     decorate: true
     labels:
       app: label-sync
@@ -10,10 +10,10 @@ periodics:
     - org: kubestellar
       repo: infra
       base_ref: main
-      clone_uri: "ssh://git@github.com/kubestellar/infra.git"
+      clone_uri: "https://github.com/kubestellar/infra.git"
     spec:
       containers:
-      - image: gcr.io/k8s-prow/label_sync:v20240731-a5d9345e59
+      - image: us-docker.pkg.dev/k8s-infra-prow/images/label_sync:v20240802-66b115076
         command:
         - label_sync
         args:


### PR DESCRIPTION
## Summary
- Change cluster from `prow` to `default` (fixes "no build client found" error)
- Change clone_uri from SSH to HTTPS
- Update image to us-docker.pkg.dev registry

## Problem
The labelsync job was failing with:
```
Terminal error: nonretryable error: no build client found for cluster "prow"
```

This prevented triage labels (`needs-triage`, `triage/accepted`, etc.) from being synced to all repos.

## Test plan
- [ ] Verify labelsync job runs successfully
- [ ] Verify labels are synced to all kubestellar repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)