### PR TITLE
Fix label_sync image to use working gcr.io version

### DIFF
--- a/prow/jobs/kubestellar/infra/infra-periodics.yaml
+++ b/prow/jobs/kubestellar/infra/infra-periodics.yaml
@@ -13,7 +13,7 @@ periodics:
       clone_uri: "https://github.com/kubestellar/infra.git"
     spec:
       containers:
-      - image: us-docker.pkg.dev/k8s-infra-prow/images/label_sync:v20240802-66b115076
+      - image: gcr.io/k8s-prow/label_sync:v20240731-a5d9345e59
         command:
         - label_sync
         args:


### PR DESCRIPTION
## Summary
- Fix labelsync periodic job image - the `us-docker.pkg.dev/k8s-infra-prow/images/label_sync:v20240802-66b115076` tag doesn't exist
- Use working `gcr.io/k8s-prow/label_sync:v20240731-a5d9345e59` image instead

## Test plan
- [x] Manual labelsync runs with this image completed successfully
- [ ] Verify periodic job runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)