### PR TITLE
Fix labelsync to sync repos sequentially to avoid hangs

### DIFF
--- a/prow/jobs/kubestellar/infra/infra-periodics.yaml
+++ b/prow/jobs/kubestellar/infra/infra-periodics.yaml
@@ -15,21 +15,44 @@ periodics:
       containers:
       - image: gcr.io/k8s-prow/label_sync:v20240731-a5d9345e59
         command:
-        - label_sync
-        args:
-        - --config=/home/prow/go/src/github.com/kubestellar/infra/prow/labels.yaml
-        - --confirm=true
-        - --orgs=kubestellar
-        - --github-app-id=1227751
-        - --github-app-private-key-path=/etc/github-app/cert
-        - --endpoint=http://ghproxy.prow.svc.cluster.local
-        - --endpoint=https://api.github.com
-        - --debug
+        - /bin/sh
+        - -c
+        - |
+          # Sync repos one at a time to avoid parallel request hangs
+          REPOS=$(label_sync --config=/home/prow/go/src/github.com/kubestellar/infra/prow/labels.yaml --orgs=kubestellar --action=docs 2>/dev/null | grep "kubestellar/" | cut -d'/' -f2 | sort -u || echo "")
+
+          # If we can't get repo list dynamically, use known repos
+          if [ -z "$REPOS" ]; then
+            REPOS=".github a2a community core docs galaxy helm homebrew-kubectl-multi homebrew-kubestellar infra kubectl-multi-plugin kubectl-rbac-flatten-plugin kubeflex kubestellar kubestellar-infrastructure kubestellar-killercoda ocm-status-addon ocm-transport-plugin presentations repo-template repo-template-go ui ui-plugins"
+          fi
+
+          FAILED=""
+          for repo in $REPOS; do
+            echo "=== Syncing kubestellar/$repo ==="
+            if label_sync \
+              --config=/home/prow/go/src/github.com/kubestellar/infra/prow/labels.yaml \
+              --confirm=true \
+              --only=kubestellar/$repo \
+              --token=/etc/oauth/token \
+              --endpoint=https://api.github.com; then
+              echo "SUCCESS: kubestellar/$repo"
+            else
+              echo "FAILED: kubestellar/$repo"
+              FAILED="$FAILED $repo"
+            fi
+            echo ""
+          done
+
+          if [ -n "$FAILED" ]; then
+            echo "Failed repos:$FAILED"
+            exit 1
+          fi
+          echo "All repos synced successfully"
         volumeMounts:
-        - name: github-app
-          mountPath: /etc/github-app
+        - name: oauth-token
+          mountPath: /etc/oauth
           readOnly: true
       volumes:
-      - name: github-app
+      - name: oauth-token
         secret:
-          secretName: github-token
+          secretName: github-oauth-token


### PR DESCRIPTION
## Summary
- Sync repos one at a time instead of all 22 in parallel to avoid GitHub API request hangs
- Use OAuth token authentication (more reliable with this image version)
- Include fallback list of known repos if dynamic detection fails

## Problem
The labelsync job was hanging when syncing all repos in parallel due to concurrent API requests getting stuck. Manual testing showed that syncing repos individually works reliably.

## Test plan
- [x] Manual testing confirmed single-repo syncs complete successfully
- [x] All repos now have triage labels synced
- [ ] Verify periodic job runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)