### PR TITLE
Add automatic needs-triage label for new issues

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -94,6 +94,10 @@ require_matching_label:
     repo: kubestellar
     prs: true
     regexp: ^kind/
+  - missing_label: needs-triage
+    org: kubestellar
+    issues: true
+    regexp: ^triage/
 
 external_plugins:
   # Org-wide external plugins


### PR DESCRIPTION
## Summary
- Configure `require_matching_label` plugin to automatically add `needs-triage` label to new issues
- Applies org-wide to all kubestellar repos
- Issues without a `triage/*` label will automatically get `needs-triage` added

## How it works
When a new issue is opened without any `triage/*` label (like `triage/accepted`, `triage/duplicate`, etc.), Prow will automatically add the `needs-triage` label. This helps maintainers identify issues that haven't been reviewed yet.

## Test plan
- [ ] Open a test issue and verify `needs-triage` is automatically added
- [ ] Add `triage/accepted` and verify `needs-triage` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)