### PR TITLE
fix: labelsync - remove deleted label and exclude archived repo

### DIFF
--- a/prow/jobs/kubestellar/infra/infra-periodics.yaml
+++ b/prow/jobs/kubestellar/infra/infra-periodics.yaml
@@ -19,11 +19,13 @@ periodics:
         - -c
         - |
           # Sync repos one at a time to avoid parallel request hangs
-          REPOS=$(label_sync --config=/home/prow/go/src/github.com/kubestellar/infra/prow/labels.yaml --orgs=kubestellar --action=docs 2>/dev/null | grep "kubestellar/" | cut -d'/' -f2 | sort -u || echo "")
+          # Exclude archived repos (ocm-transport-plugin)
+          REPOS=$(label_sync --config=/home/prow/go/src/github.com/kubestellar/infra/prow/labels.yaml --orgs=kubestellar --action=docs 2>/dev/null | grep "kubestellar/" | cut -d'/' -f2 | grep -v "ocm-transport-plugin" | sort -u || echo "")
 
           # If we can't get repo list dynamically, use known repos
+          # Note: ocm-transport-plugin is excluded because it's archived
           if [ -z "$REPOS" ]; then
-            REPOS=".github a2a community core docs galaxy helm homebrew-kubectl-multi homebrew-kubestellar infra kubectl-multi-plugin kubectl-rbac-flatten-plugin kubeflex kubestellar kubestellar-infrastructure kubestellar-killercoda ocm-status-addon ocm-transport-plugin presentations repo-template repo-template-go ui ui-plugins"
+            REPOS=".github a2a community core docs galaxy helm homebrew-kubectl-multi homebrew-kubestellar infra kubectl-multi-plugin kubectl-rbac-flatten-plugin kubeflex kubestellar kubestellar-infrastructure kubestellar-killercoda ocm-status-addon presentations repo-template repo-template-go ui ui-plugins"
           fi
 
           FAILED=""

--- a/prow/labels.yaml
+++ b/prow/labels.yaml
@@ -539,11 +539,6 @@ orgs:
         name: triage/support
         target: both
         addedBy: humans
-      - color: DD5AFE
-        description: Question about whether this issue is still valid
-        name: is this still valid?
-        target: issues
-        addedBy: humans
       - color: CB13CB
         description: Related to space framework
         name: space framework


### PR DESCRIPTION
## Fixes
- Removed "is this still valid?" label from labels.yaml (was deleted from kubestellar/kubestellar repo, causing 404 errors)
- Excluded ocm-transport-plugin from labelsync (repo is archived)

This fixes the hourly labelsync job failures.