### PR TITLE
Update labelsync to use GitHub App authentication

### DIFF
--- a/prow/jobs/kubestellar/infra/infra-periodics.yaml
+++ b/prow/jobs/kubestellar/infra/infra-periodics.yaml
@@ -13,7 +13,7 @@ periodics:
       clone_uri: "https://github.com/kubestellar/infra.git"
     spec:
       containers:
-      - image: gcr.io/k8s-prow/label_sync:v20240731-a5d9345e59
+      - image: us-docker.pkg.dev/k8s-infra-prow/images/label_sync:v20260109-e821f0db6
         command:
         - /bin/sh
         - -c
@@ -35,8 +35,9 @@ periodics:
               --config=/home/prow/go/src/github.com/kubestellar/infra/prow/labels.yaml \
               --confirm=true \
               --only=kubestellar/$repo \
-              --token=/etc/oauth/token \
-              --endpoint=https://api.github.com; then
+              --github-app-id=$GITHUB_APP_ID \
+              --github-app-private-key-path=/etc/github/cert \
+              --github-endpoint=https://api.github.com; then
               echo "SUCCESS: kubestellar/$repo"
             else
               echo "FAILED: kubestellar/$repo"
@@ -50,14 +51,20 @@ periodics:
             exit 1
           fi
           echo "All repos synced successfully"
+        env:
+        - name: GITHUB_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: github-token
+              key: appid
         volumeMounts:
-        - name: oauth-token
-          mountPath: /etc/oauth
+        - name: github-token
+          mountPath: /etc/github
           readOnly: true
       volumes:
-      - name: oauth-token
+      - name: github-token
         secret:
-          secretName: github-oauth-token
+          secretName: github-token
 
   - name: ci-infra-prow-autobump
     cron: "30 3 * * 1"  # Weekly on Monday at 3:30 AM UTC


### PR DESCRIPTION
## Summary
- Switch labelsync from PAT-based auth to GitHub App auth
- Update label_sync image to v20260109
- Use `github-token` secret instead of `github-oauth-token`

This eliminates the need for a separate PAT for label syncing.

## Changes
- `--token` flag → `--github-app-id` + `--github-app-private-key-path`
- Volume mount changed from `github-oauth-token` to `github-token`
- Added `GITHUB_APP_ID` env var from secret

## Test plan
- [ ] Wait for next hourly run at :17 past the hour
- [ ] Check job logs for successful label sync

---
Generated with [Claude Code](https://claude.ai/code)