### PR TITLE
🌱 feat: add reusable workflows for org-wide CI standardization

### DIFF
--- a/.github/workflows/reusable-add-help-wanted.yml
+++ b/.github/workflows/reusable-add-help-wanted.yml
@@ -1,0 +1,38 @@
+name: Reusable Add Help Wanted Label
+
+on:
+  workflow_call:
+
+jobs:
+  add-help-wanted:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          script: |
+            const issue = context.payload.issue;
+            if (!issue) return;
+
+            // Check if the issue already has help-wanted or good-first-issue labels
+            const labels = issue.labels.map(l => l.name);
+            const hasHelpLabel = labels.some(l =>
+              l === 'help wanted' || l === 'good first issue'
+            );
+
+            if (hasHelpLabel) {
+              console.log('Issue already has help-wanted or good-first-issue label');
+              return;
+            }
+
+            // Add help-wanted label to issues that are not assigned
+            if (!issue.assignee && !issue.assignees?.length) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['help wanted']
+              });
+              console.log('Added help-wanted label to issue #' + issue.number);
+            }

--- a/.github/workflows/reusable-feedback.yml
+++ b/.github/workflows/reusable-feedback.yml
@@ -1,0 +1,32 @@
+name: Reusable Feedback
+
+on:
+  workflow_call:
+    inputs:
+      survey_url:
+        description: 'URL to the feedback survey'
+        required: false
+        type: string
+        default: 'https://kubestellar.io/survey'
+
+jobs:
+  feedback:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+    steps:
+      - name: Comment feedback request
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1uj5fcc
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Thank you for your contribution! Your PR has been successfully merged.
+
+            We'd love to hear your thoughts to help improve KubeStellar.
+            Please take a moment to fill out our short feedback survey:
+
+            ${{ inputs.survey_url }}

--- a/.github/workflows/reusable-greetings.yml
+++ b/.github/workflows/reusable-greetings.yml
@@ -1,0 +1,38 @@
+name: Reusable Greetings
+
+on:
+  workflow_call:
+    inputs:
+      issue_message:
+        description: 'Custom message for first-time issue contributors'
+        required: false
+        type: string
+        default: |
+          Thank you for contributing your first Issue to KubeStellar. We are delighted to have you in our Universe!
+
+          To assign yourself to this issue, please use the slash command:
+          ```
+          /assign
+          ```
+
+          This will automatically assign the issue to you via our Prow bot. You can also use `/unassign` to remove yourself from an issue.
+
+          Thank you for your interest in contributing to KubeStellar!
+      pr_message:
+        description: 'Custom message for first-time PR contributors'
+        required: false
+        type: string
+        default: 'Thank you for submitting your first Pull Request to KubeStellar. We are delighted to have you in our Universe!'
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: ${{ inputs.issue_message }}
+          pr_message: ${{ inputs.pr_message }}

--- a/.github/workflows/reusable-pr-verifier.yml
+++ b/.github/workflows/reusable-pr-verifier.yml
@@ -1,0 +1,20 @@
+name: Reusable PR Verifier
+
+on:
+  workflow_call:
+
+jobs:
+  verify-pr:
+    name: verify PR contents
+    # Skip verification for dependabot PRs - they use different title conventions
+    if: github.actor != 'dependabot[bot]'
+    permissions:
+      checks: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verifier action
+        id: verifier
+        uses: kubernetes-sigs/kubebuilder-release-tools@v0.4.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-pr-verify-title.yml
+++ b/.github/workflows/reusable-pr-verify-title.yml
@@ -1,0 +1,38 @@
+name: Reusable PR Title Verifier
+
+on:
+  workflow_call:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Validate PR Title Format
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${TITLE}" ]; then
+            echo "Error: PR title cannot be empty."
+            exit 1
+          fi
+
+          # Define allowed emoji prefixes
+          if ! printf '%s' "$TITLE" | grep -qE '^(\xE2\x9A\xA0|\xE2\x9C\xA8|\xF0\x9F\x90\x9B|\xF0\x9F\x93\x96|\xF0\x9F\x9A\x80|\xF0\x9F\x8C\xB1)'; then
+            printf "Required indicator not found at the start of title: %q\n" "$TITLE"
+            echo "Your PR title must start with one of the following:"
+            echo "  Warning sign (Breaking change)"
+            echo "  Sparkles (Non-breaking feature)"
+            echo "  Bug (Patch fix)"
+            echo "  Book (Documentation)"
+            echo "  Rocket (Release)"
+            echo "  Seedling (Infra/Tests/Other)"
+            exit 1
+          fi
+
+          printf "PR title is valid: '%q'\n" "$TITLE"

--- a/.github/workflows/reusable-scorecard.yml
+++ b/.github/workflows/reusable-scorecard.yml
@@ -1,0 +1,41 @@
+name: Reusable OpenSSF Scorecard
+
+on:
+  workflow_call:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/reusable-stale.yml
+++ b/.github/workflows/reusable-stale.yml
@@ -1,0 +1,46 @@
+name: Reusable Stale Issues
+
+on:
+  workflow_call:
+    inputs:
+      days_before_stale:
+        description: 'Days before marking issue as stale'
+        required: false
+        type: number
+        default: 90
+      days_before_close:
+        description: 'Days before closing stale issue'
+        required: false
+        type: number
+        default: 90
+      exempt_labels:
+        description: 'Comma-separated labels exempt from stale'
+        required: false
+        type: string
+        default: 'security,bug,enhancement,good first issue,help wanted,hacktober-fest,lifecycle/frozen'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e
+        with:
+          days-before-issue-stale: ${{ inputs.days_before_stale }}
+          days-before-issue-close: ${{ inputs.days_before_close }}
+          stale-issue-label: lifecycle/stale
+          stale-pr-label: lifecycle/stale
+          stale-issue-message: >-
+            This issue has been automatically marked as stale because it has not had recent activity.
+            It will be closed in ${{ inputs.days_before_close }} days if no further activity occurs. If this is still relevant,
+            please add a comment to keep it open.
+          close-issue-message: >-
+            Closing this issue due to prolonged inactivity after being marked as stale. If this remains
+            an active concern, feel free to reopen or create a new issue with updated details.
+          close-issue-label: lifecycle/auto-closed
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          exempt-issue-labels: ${{ inputs.exempt_labels }}
+          exempt-pr-labels: security,lifecycle/frozen
+          exempt-all-assignees: true


### PR DESCRIPTION
## Summary
Add centralized reusable workflows that can be called from all KubeStellar repos:

- **reusable-greetings.yml**: First-time contributor welcome messages
- **reusable-feedback.yml**: Post-merge survey request  
- **reusable-stale.yml**: Stale issue/PR management (configurable days)
- **reusable-pr-verifier.yml**: Kubebuilder PR verification
- **reusable-pr-verify-title.yml**: Emoji prefix title validation
- **reusable-add-help-wanted.yml**: Auto-label unassigned issues
- **reusable-scorecard.yml**: OpenSSF Scorecard analysis

## Usage
Repos can call these workflows like:

```yaml
name: Greetings
on:
  pull_request_target:
    types: [opened, reopened]
  issues:
    types: [opened, reopened]
jobs:
  greet:
    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
    secrets: inherit
```

## Benefits
- Single source of truth for common CI workflows
- Easier maintenance and updates
- Consistent behavior across all repos
- Repos control when to adopt updates

## Next Steps
After merging, update repos to use these reusable workflows.