### PR TITLE
🐛 fix: Use actual emoji characters in PR title regex

### DIFF
--- a/.github/workflows/reusable-pr-verify-title.yml
+++ b/.github/workflows/reusable-pr-verify-title.yml
@@ -22,16 +22,16 @@ jobs:
             exit 1
           fi
 
-          # Define allowed emoji prefixes
-          if ! printf '%s' "$TITLE" | grep -qE '^(\xE2\x9A\xA0|\xE2\x9C\xA8|\xF0\x9F\x90\x9B|\xF0\x9F\x93\x96|\xF0\x9F\x9A\x80|\xF0\x9F\x8C\xB1)'; then
+          # Define allowed emoji prefixes (⚠️ ✨ 🐛 📖 🚀 🌱)
+          if ! printf '%s' "$TITLE" | grep -qE '^(⚠|✨|🐛|📖|🚀|🌱)'; then
             printf "Required indicator not found at the start of title: %q\n" "$TITLE"
             echo "Your PR title must start with one of the following:"
-            echo "  Warning sign (Breaking change)"
-            echo "  Sparkles (Non-breaking feature)"
-            echo "  Bug (Patch fix)"
-            echo "  Book (Documentation)"
-            echo "  Rocket (Release)"
-            echo "  Seedling (Infra/Tests/Other)"
+            echo "  ⚠ Warning sign (Breaking change)"
+            echo "  ✨ Sparkles (Non-breaking feature)"
+            echo "  🐛 Bug (Patch fix)"
+            echo "  📖 Book (Documentation)"
+            echo "  🚀 Rocket (Release)"
+            echo "  🌱 Seedling (Infra/Tests/Other)"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Replace hex escape sequences with actual emoji characters in the PR title validation regex
- The hex escapes (`\xF0\x9F\x90\x9B` etc.) don't work reliably with `grep -E` across systems
- Using actual emoji characters (⚠ ✨ 🐛 📖 🚀 🌱) is more readable and reliable

## Test plan
- [ ] Verify PR title validation works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)