### PR TITLE
🌱 Clarify title error is about a special character

### DIFF
--- a/.github/workflows/reusable-pr-verify-title.yml
+++ b/.github/workflows/reusable-pr-verify-title.yml
@@ -25,13 +25,17 @@ jobs:
           # Define allowed emoji prefixes (⚠️ ✨ 🐛 📖 🚀 🌱)
           if ! printf '%s' "$TITLE" | grep -qE '^(⚠|✨|🐛|📖|🚀|🌱)'; then
             printf "Required indicator not found at the start of title: %q\n" "$TITLE"
-            echo "Your PR title must start with one of the following:"
-            echo "  ⚠ Warning sign (Breaking change)"
-            echo "  ✨ Sparkles (Non-breaking feature)"
-            echo "  🐛 Bug (Patch fix)"
-            echo "  📖 Book (Documentation)"
-            echo "  🚀 Rocket (Release)"
-            echo "  🌱 Seedling (Infra/Tests/Other)"
+            echo "Your PR title must start with one of the following special characters:"
+            echo "⚠ (indicates Breaking change)"
+            echo "✨ (indicates Non-breaking feature)"
+            echo "🐛 (indicates Patch fix)"
+            echo "📖 (indicates Documentation)"
+            echo "🚀 (indicates Release)"
+            echo "🌱 (indicates Infra/Tests/Other)"
+            echo -n "Your title's first character is, in hex: "
+6 months ago
+Add diagnostic to PR title failure
+            python3 -c "import os; print('%x' % ord(os.environ['TITLE'][0]))"
             exit 1
           fi
 


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

This PR changes the error message from the PR title checking workflow to clearly say that what is expected is a special character at the start. This is good because we have had much experience with contributors writing literal words and shortcuts rather than the actual special character.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #<issue_number>

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated `.github/workflows/reusable-pr-verify-title.yml`

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
