### PR TITLE
🐛 Pin kubebuilder-release-tools to commit hash

### DIFF
--- a/.github/workflows/reusable-pr-verifier.yml
+++ b/.github/workflows/reusable-pr-verifier.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Verifier action
         id: verifier
-        uses: kubernetes-sigs/kubebuilder-release-tools@v0.4.3
+        uses: kubernetes-sigs/kubebuilder-release-tools@012269a88fa4c034a0acf1ba84c26b195c0dbab4 # v0.4.3
         continue-on-error: true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Pin kubernetes-sigs/kubebuilder-release-tools to commit hash `012269a88fa4c034a0acf1ba84c26b195c0dbab4` instead of version tag `v0.4.3`
- Complies with KubeStellar's GitHub Action reference discipline

## Issue
Fixes the **Verify Action Hashes** workflow failure in kubestellar/kubestellar.

The workflow was failing with:
```
ERROR: Action reference problems found; .github/workflows/pr-verifier.yml uses kubernetes-sigs/kubebuilder-release-tools@v0.4.3, whose version v0.4.3 is not a commit hash
```

🤖 Generated with [Claude Code](https://claude.ai/code)