### PR TITLE
🌱 Test: Verify Prow job triggering after hook fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ To access Prow, there are 2 instances of its UI:
 
 * https://prow2-private.kubestellar.io/ is the _internal_ Deck, available only to authenticated users (users part of the `kubestellar-dev` organization). This deck shows _all_ repositories and offers a way to rerun a Prowjob.
 * https://prow2.kubestellar.io/ is the _public_ Deck, available to everyone, but read-only.
+# Test 1768269848


### PR DESCRIPTION
Testing if `pull-infra-validate-prow-yaml` now triggers after fixing the hook deployment to include job-config.