### PR TITLE
🐛 Fix: Use HTTPS clone URI for infra presubmit jobs

### DIFF
--- a/prow/jobs/kubestellar/infra/infra-presubmits.yaml
+++ b/prow/jobs/kubestellar/infra/infra-presubmits.yaml
@@ -3,7 +3,7 @@ presubmits:
     - name: pull-infra-validate-prow-yaml
       always_run: true
       decorate: true
-      clone_uri: "ssh://git@github.com/kubestellar/infra.git"
+      clone_uri: "https://github.com/kubestellar/infra.git"
       spec:
         containers:
           - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20260109-e821f0db6
@@ -17,7 +17,7 @@ presubmits:
 
     - name: pull-infra-validate-prow-jobs
       decorate: true
-      clone_uri: "ssh://git@github.com/kubestellar/infra.git"
+      clone_uri: "https://github.com/kubestellar/infra.git"
       run_if_changed: "prow/jobs/"
       branches:
         - ^main$
@@ -37,7 +37,7 @@ presubmits:
       labels:
         app: label-sync
       decorate: true
-      clone_uri: "ssh://git@github.com/kubestellar/infra.git"
+      clone_uri: "https://github.com/kubestellar/infra.git"
       run_if_changed: '^prow/labels.yaml$'
       spec:
         containers:


### PR DESCRIPTION
## Summary
- Changed clone_uri from `ssh://git@github.com/kubestellar/infra.git` to `https://github.com/kubestellar/infra.git` for all infra presubmit jobs

## Problem
The `pull-infra-validate-prow-yaml` job was failing with:
```
Permission denied (publickey).
fatal: Could not read from remote repository.
```

This is because SSH clone URIs don't work with GitHub App tokens - Prow tries to inject the token into an SSH URL which isn't valid.

## Root Cause
Two issues were fixed:
1. **Hook deployment missing job-config** - The hook was not loading presubmit job definitions (fixed via cluster patch)
2. **SSH clone URI incompatible with GitHub App** - This PR fixes the job definitions to use HTTPS

## Test Plan
- [x] Verified hook now has `--job-config-path` and mounts `job-config` ConfigMap
- [ ] Verify `pull-infra-validate-prow-yaml` passes on this PR