### PR TITLE
🌱 Fix strict validation warnings in Prow config

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1,6 +1,5 @@
 prowjob_namespace: prow
 pod_namespace: test-pods
-job_config_path: prow/jobs
 
 plank:
   pod_pending_timeout: 60m
@@ -235,6 +234,7 @@ periodics:
   - interval: 60m  # Existing echo-test job
     agent: kubernetes
     name: echo-test
+    decorate: true
     spec:
       containers:
         - image: ghcr.io/kubestellar/infra/alpine:3.22.0


### PR DESCRIPTION
## Summary
- Remove `job_config_path` field which is unknown in the config schema
- Add `decorate: true` to echo-test periodic job so it uses pod utilities

These changes fix warnings that cause `pull-infra-validate-prow-jobs` to fail when using the `-strict` flag.

## Test plan
- [ ] Verify `pull-infra-validate-prow-yaml` passes
- [ ] Verify `pull-infra-validate-prow-jobs` passes with strict validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)