### PR TITLE
🌱 Test: Verify strict validation works

### DIFF
--- a/prow/jobs/kubestellar/infra/infra-presubmits.yaml
+++ b/prow/jobs/kubestellar/infra/infra-presubmits.yaml
@@ -1,3 +1,4 @@
+# Presubmit jobs for kubestellar/infra repository
 presubmits:
   kubestellar/infra:
     - name: pull-infra-validate-prow-yaml


### PR DESCRIPTION
## Summary
Test PR to verify `pull-infra-validate-prow-jobs` works after the strict validation fix in PR #63.

Adding a harmless comment to trigger the job.

## Test plan
- [ ] Verify `pull-infra-validate-prow-yaml` passes
- [ ] Verify `pull-infra-validate-prow-jobs` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)