### PR TITLE
🐛 Fix uv PATH in a2a presubmit jobs

### DIFF
--- a/prow/jobs/kubestellar/a2a/a2a-presubmits.yaml
+++ b/prow/jobs/kubestellar/a2a/a2a-presubmits.yaml
@@ -34,7 +34,7 @@ presubmits:
               - |
                 # Install uv package manager
                 curl -LsSf https://astral.sh/uv/install.sh | sh
-                export PATH="/root/.cargo/bin:$PATH"
+                export PATH="/root/.local/bin:$PATH"
                 
                 # Install dependencies
                 uv sync --dev
@@ -59,7 +59,7 @@ presubmits:
               - |
                 # Install uv package manager
                 curl -LsSf https://astral.sh/uv/install.sh | sh
-                export PATH="/root/.cargo/bin:$PATH"
+                export PATH="/root/.local/bin:$PATH"
                 
                 # Install dependencies
                 uv sync --dev
@@ -84,7 +84,7 @@ presubmits:
               - |
                 # Install uv package manager
                 curl -LsSf https://astral.sh/uv/install.sh | sh
-                export PATH="/root/.cargo/bin:$PATH"
+                export PATH="/root/.local/bin:$PATH"
                 
                 # Install dependencies
                 uv sync --dev


### PR DESCRIPTION
## Summary
Fixes the PATH for the `uv` package manager in a2a presubmit jobs.

## Problem
The jobs were failing with:
```
/bin/bash: line 6: uv: command not found
```

## Root Cause
- Central config had: `export PATH="/root/.cargo/bin:$PATH"`
- uv installs to: `/root/.local/bin`

## Fix
Changed PATH to `/root/.local/bin:$PATH` in all 3 a2a presubmit jobs.

## Test plan
- [ ] Retest a2a jobs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)