### PR TITLE
🐛 Remove validate-prow-yaml job from a2a

### DIFF
--- a/prow/jobs/kubestellar/a2a/a2a-presubmits.yaml
+++ b/prow/jobs/kubestellar/a2a/a2a-presubmits.yaml
@@ -1,26 +1,5 @@
 presubmits:
   kubestellar/a2a:
-    - name: pull-kubestellar-a2a-validate-prow-yaml
-      always_run: true
-      optional: true
-      decorate: true
-      clone_uri: "ssh://git@github.com/kubestellar/a2a.git"
-      extra_refs:
-        - org: kubestellar
-          repo: infra
-          base_ref: main
-          clone_uri: git@github.com:kubestellar/infra.git
-      spec:
-        containers:
-          - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20260109-e821f0db6
-            command:
-              - checkconfig
-            args:
-              - -plugin-config=/home/prow/go/src/github.com/kubestellar/infra/prow/plugins.yaml
-              - -config-path=/home/prow/go/src/github.com/kubestellar/infra/prow/config.yaml
-              - -job-config-path=/home/prow/go/src/github.com/kubestellar/infra/prow/jobs
-              - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)
-
     - name: pull-kubestellar-a2a-verify
       always_run: true
       decorate: true


### PR DESCRIPTION
## Summary
Removes the `pull-kubestellar-a2a-validate-prow-yaml` job since the a2a repo no longer has a `.prow.yaml` file.

## Context
The `.prow.yaml` was removed from a2a in PR #173 to fix duplicate job conflicts with the central config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)