### PR TITLE
🐛 Fix SSH clone URIs to use HTTPS in Prow jobs

### DIFF
--- a/prow/jobs/kubestellar/infra/infra-periodics-lifecycle.yaml
+++ b/prow/jobs/kubestellar/infra/infra-periodics-lifecycle.yaml
@@ -10,7 +10,7 @@ periodics:
       - org: kubestellar
         repo: infra
         base_ref: main
-        clone_uri: "git@github.com:kubestellar/infra.git"
+        clone_uri: "https://github.com/kubestellar/infra.git"
     spec:
       containers:
         - image: gcr.io/k8s-prow/commenter:v20230523-2834e18241
@@ -46,7 +46,7 @@ periodics:
       - org: kubestellar
         repo: infra
         base_ref: main
-        clone_uri: "git@github.com:kubestellar/infra.git"
+        clone_uri: "https://github.com/kubestellar/infra.git"
     spec:
       containers:
         - image: gcr.io/k8s-prow/commenter:v20230523-2834e18241
@@ -82,7 +82,7 @@ periodics:
       - org: kubestellar
         repo: infra
         base_ref: main
-        clone_uri: "git@github.com:kubestellar/infra.git"
+        clone_uri: "https://github.com/kubestellar/infra.git"
     spec:
       containers:
         - image: gcr.io/k8s-prow/commenter:v20230523-2834e18241

--- a/prow/jobs/kubestellar/kubeflex/kubeflex-presubmits.yaml
+++ b/prow/jobs/kubestellar/kubeflex/kubeflex-presubmits.yaml
@@ -4,12 +4,12 @@ presubmits:
       always_run: true
       optional: true
       decorate: true
-      clone_uri: "ssh://git@github.com/kubestellar/kubeflex.git"
+      clone_uri: "https://github.com/kubestellar/kubeflex.git"
       extra_refs:
         - org: kubestellar
           repo: infra
           base_ref: main
-          clone_uri: git@github.com:kubestellar/infra.git
+          clone_uri: https://github.com/kubestellar/infra.git
       spec:
         containers:
           - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20260109-e821f0db6

--- a/prow/jobs/kubestellar/kubestellar/kubestellar-presubmits.yaml
+++ b/prow/jobs/kubestellar/kubestellar/kubestellar-presubmits.yaml
@@ -4,12 +4,12 @@ presubmits:
       always_run: true
       optional: true
       decorate: true
-      clone_uri: "ssh://git@github.com/kubestellar/kubestellar.git"
+      clone_uri: "https://github.com/kubestellar/kubestellar.git"
       extra_refs:
         - org: kubestellar
           repo: infra
           base_ref: main
-          clone_uri: git@github.com:kubestellar/infra.git
+          clone_uri: https://github.com/kubestellar/infra.git
       spec:
         containers:
           - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20260109-e821f0db6

--- a/prow/jobs/kubestellar/ui/ui-presubmits.yaml
+++ b/prow/jobs/kubestellar/ui/ui-presubmits.yaml
@@ -4,12 +4,12 @@ presubmits:
       always_run: true
       optional: true
       decorate: true
-      clone_uri: "ssh://git@github.com/kubestellar/kubestellar.git"
+      clone_uri: "https://github.com/kubestellar/ui.git"
       extra_refs:
         - org: kubestellar
           repo: infra
           base_ref: main
-          clone_uri: git@github.com:kubestellar/infra.git
+          clone_uri: https://github.com/kubestellar/infra.git
       spec:
         containers:
           - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20260109-e821f0db6


### PR DESCRIPTION
## Summary
Fix validate-prow-yaml jobs that were failing due to SSH clone URIs.

GitHub App tokens don't work with SSH authentication, so all clone_uri values need to use HTTPS.

## Changes
- kubestellar-presubmits.yaml: SSH → HTTPS
- ui-presubmits.yaml: SSH → HTTPS (also fixed wrong repo - was cloning kubestellar instead of ui)
- kubeflex-presubmits.yaml: SSH → HTTPS
- infra-periodics-lifecycle.yaml: SSH → HTTPS

## Test
After merge, `/retest` the failing validate-prow-yaml jobs on test PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)