### PR TITLE
🐛 Fix CI workflow and Prow job issues

### DIFF
--- a/.github/workflows/reusable-feedback.yml
+++ b/.github/workflows/reusable-feedback.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     steps:
       - name: Comment feedback request
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1a35fcc
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         continue-on-error: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-scorecard.yml
+++ b/.github/workflows/reusable-scorecard.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
-      id-token: write
       contents: read
       actions: read
 
@@ -26,7 +25,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: true
+          publish_results: false
 
       - name: Upload artifact
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882

--- a/prow/jobs/kubestellar/a2a/a2a-presubmits.yaml
+++ b/prow/jobs/kubestellar/a2a/a2a-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
                 export PATH="/root/.local/bin:$PATH"
                 
                 # Install dependencies
-                uv sync --dev
+                uv sync --dev --python-preference only-system
                 
                 # Run tests with pytest and coverage
                 uv run pytest tests/ -v --cov=src/ --cov-report=xml --cov-report=term
@@ -41,7 +41,7 @@ presubmits:
                 export PATH="/root/.local/bin:$PATH"
                 
                 # Install dependencies
-                uv sync --dev
+                uv sync --dev --python-preference only-system
                 
                 # Run tests with pytest and coverage
                 uv run pytest tests/ -v --cov=src/ --cov-report=xml --cov-report=term
@@ -66,7 +66,7 @@ presubmits:
                 export PATH="/root/.local/bin:$PATH"
                 
                 # Install dependencies
-                uv sync --dev
+                uv sync --dev --python-preference only-system
                 
                 # Lint with ruff
                 echo "Running ruff..."


### PR DESCRIPTION
## Summary
Fixes three CI issues:

1. **Feedback Wanted workflow** - Invalid action SHA for peter-evans/create-or-update-comment
   - Changed `71345be0265236311c031f5c7866368bd1a35fcc` to `71345be0265236311c031f5c7866368bd1eff043` (v4)

2. **OpenSSF Scorecard workflow** - Webapp rejecting write permissions
   - Removed `id-token: write` permission
   - Disabled `publish_results` to avoid webapp verification

3. **a2a Prow jobs** - cffi build failing due to missing C compiler
   - Added `--python-preference only-system` to `uv sync` to use container Python 3.11/3.12 instead of downloading Python 3.14 which lacks pre-built wheels

## Test plan
- [ ] Verify Feedback Wanted workflow runs on merged PR
- [ ] Verify OpenSSF Scorecard workflow completes without error
- [ ] Verify a2a Prow jobs pass (pull-kubestellar-a2a-verify, pull-kubestellar-a2a-lint)

Generated with [Claude Code](https://claude.com/claude-code)