### PR TITLE
✨ Add reusable assignment-helper workflow

### DIFF
--- a/.github/workflows/reusable-assignment-helper.yml
+++ b/.github/workflows/reusable-assignment-helper.yml
@@ -1,0 +1,84 @@
+name: Reusable Assignment Helper
+
+on:
+  workflow_call:
+    inputs:
+      contributing_guide_url:
+        description: 'URL to the contributing guide'
+        required: false
+        type: string
+        default: 'https://github.com/kubestellar/kubestellar/blob/main/CONTRIBUTING.md'
+
+jobs:
+  assignment-helper:
+    # Only run on issues (not PRs) and exclude bot comments
+    if: github.event.issue.pull_request == null && github.event.comment.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Check for assignment request and respond
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          script: |
+            const comment = context.payload.comment.body.toLowerCase();
+            const issue_number = context.payload.issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const commenter = context.payload.comment.user.login;
+
+            // Don't trigger if the comment is exactly "/assign" - that's handled by Prow
+            if (comment.trim() === '/assign') {
+              console.log('Exact /assign command detected, skipping helper response');
+              return;
+            }
+
+            // Check if the comment contains natural language requests for assignment
+            const assignmentPatterns = [
+              /can\s+you\s+assign/,
+              /could\s+you\s+assign/,
+              /please\s+assign/,
+              /assign\s+me/,
+              /can\s+i\s+be\s+assigned/,
+              /could\s+i\s+be\s+assigned/,
+              /i\s+would\s+like\s+to\s+be\s+assigned/,
+              /assign\s+this\s+to\s+me/,
+              /can\s+i\s+take\s+this/,
+              /can\s+i\s+work\s+on\s+this/,
+              /could\s+i\s+work\s+on\s+this/,
+              /i\s+want\s+to\s+work\s+on\s+this/,
+              /assign\s+.*\s+to\s+me/,
+              /can\s+.*\s+assign.*me/,
+              /could.*assign.*me/
+            ];
+
+            const hasAssignmentRequest = assignmentPatterns.some(pattern => pattern.test(comment));
+
+            if (hasAssignmentRequest) {
+              console.log('Assignment request detected in comment');
+
+              const contributingUrl = '${{ inputs.contributing_guide_url }}';
+              const responseMessage = `👋 Hi @${commenter}!
+
+            To assign yourself to this issue, please use the slash command:
+            \`\`\`
+            /assign
+            \`\`\`
+
+            This will automatically assign the issue to you via our Prow bot. You can also use \`/unassign\` to remove yourself from an issue.
+
+            📚 For more information about contributing, please check out our [Contributors Guide](${contributingUrl}).
+
+            Thank you for your interest in contributing to KubeStellar! 🚀`;
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: responseMessage,
+              });
+
+              console.log('Assignment helper response posted');
+            } else {
+              console.log('No assignment request detected in comment');
+            }


### PR DESCRIPTION
## Summary
Adds a reusable assignment-helper workflow that can be used across all repos.

**What it does:**
- Detects natural language assignment requests like "can you assign me?", "can I work on this?"
- Responds with instructions to use the `/assign` slash command
- Configurable contributing guide URL

**Usage in repos:**
```yaml
name: Assignment Helper

on:
  issue_comment:
    types: [created]

jobs:
  assignment-helper:
    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@main
```

Generated with [Claude Code](https://claude.com/claude-code)