### PR TITLE
🐛 Fix reusable-feedback.yml: remove issues: write permission

### DIFF
--- a/.github/workflows/reusable-feedback.yml
+++ b/.github/workflows/reusable-feedback.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      issues: write
       contents: read
     steps:
       - name: Comment feedback request


### PR DESCRIPTION
## Summary
- Remove unnecessary `issues: write` permission from reusable-feedback.yml

The `issues: write` permission is not needed for commenting on PRs (only `pull-requests: write` is needed). This was causing `startup_failure` in caller workflows that didn't have `issues: write`.

## Test plan
- [ ] Merge this PR
- [ ] Create a test PR in .github repo and merge it
- [ ] Verify Feedback Wanted workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)