### PR TITLE
🐛 Fix greetings.yml: move permissions to workflow level

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -2,16 +2,16 @@ name: Greetings
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, reopened]
   issues:
-    types: [opened]
+    types: [opened, reopened]
 
 permissions:
   contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   greeting:
     uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
-    permissions:
-      issues: write
-      pull-requests: write
+    secrets: inherit


### PR DESCRIPTION
Job-level permissions don't work with reusable workflow calls.