### PR TITLE
🐛 Fix label-helper workflow permissions

### DIFF
--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -6,10 +6,10 @@ on:
 
 permissions:
   contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   label-helper:
     uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@main
-    permissions:
-      issues: write
-      pull-requests: write
+    secrets: inherit


### PR DESCRIPTION
## Summary
Fix startup_failure in label-helper workflow by matching the permission pattern from the working greetings.yml.

## Changes
- Move permissions to top level
- Add `secrets: inherit` to job

🤖 Generated with [Claude Code](https://claude.com/claude-code)