### PR TITLE
🌱 Exclude private and archived repos from workflow sync

### DIFF
--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -29,8 +29,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_SYNC_TOKEN }}
         run: |
-          # Get all repos in org, excluding .github, infra, and archived repos
-          repos=$(gh repo list kubestellar --limit 100 --json name,isArchived --jq '[.[] | select(.isArchived == false) | .name | select(. != ".github" and . != "infra")]')
+          # Get all repos in org, excluding .github, infra, private repos, and archived repos
+          # Private repos (core, homebrew-kubestellar) are excluded because some workflows like scorecard don't work with them
+          repos=$(gh repo list kubestellar --limit 100 --json name,isArchived,isPrivate --jq '[.[] | select(.isArchived == false and .isPrivate == false) | .name | select(. != ".github" and . != "infra")]')
           echo "repos=$repos" >> $GITHUB_OUTPUT
           echo "Found repos: $repos"
 


### PR DESCRIPTION
## Summary
- Excludes private repos (like `core` and `homebrew-kubestellar`) from workflow sync
- These repos don't work with workflows like OpenSSF Scorecard
- Filter now checks both `isArchived == false` and `isPrivate == false`

## Changes
- Updated `sync-workflows.yml` to add `isPrivate` to the jq filter

## Test Plan
- [ ] Trigger workflow manually and verify private repos are not in the target list