### PR TITLE
🐛 Fix feedback workflow to use correct survey URL

### DIFF
--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -1,28 +1,14 @@
-name: Feedback Wanted
+name: Feedback
 
 on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   feedback:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      issues: write
-      contents: read
-
-    steps:
-      - name: Comment feedback request
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            🎉 Thank you for your contribution! Your PR has been successfully merged.
-
-            We’d love to hear your thoughts to help improve KubeStellar.
-            Please take a moment to fill out our short feedback survey:
-
-            https://kubestellar.io/survey
+    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
The feedback workflow in infra was not using the reusable workflow and had an old survey URL (`kubestellar.io/survey`).

## Changes
- Updated `feedback.yml` to use `reusable-feedback.yml` which has the correct multi-cluster survey URL (`forms.gle/VsG6aJpikf3NKjJH6`)

## Before
```
https://kubestellar.io/survey
```

## After
Uses the reusable workflow with the multi-cluster survey link.