### PR TITLE
🌱 Add missing caller workflows to infra repo

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -1,0 +1,13 @@
+name: Add Help Wanted Label
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@main
+    secrets: inherit

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -1,0 +1,12 @@
+name: Assignment Helper
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  assignment-helper:
+    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@main

--- a/.github/workflows/pr-verify-title.yml
+++ b/.github/workflows/pr-verify-title.yml
@@ -1,0 +1,13 @@
+name: "PR Title Verifier"
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    uses: kubestellar/infra/.github/workflows/reusable-pr-verify-title.yml@main
+    secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,20 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '0 6 * * 1'
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+  id-token: write
+
+jobs:
+  analysis:
+    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
Infra was missing caller workflows that are synced to other repos. Even though infra is the home of the reusable definitions, it still needs the caller workflows for its own use.

## Added
- `add-help-wanted.yml`
- `assignment-helper.yml`
- `pr-verify-title.yml`
- `scorecard.yml`

## Infra workflow structure
```
.github/workflows/
├── reusable-*.yml      # Workflow definitions (called by other repos)
├── *.yml               # Caller workflows (for infra's own use)
├── docs-link-checker.yml  # Infra-only
└── sync-workflows.yml     # Infra-only
```