### PR TITLE
🌱 Add reusable image scanning workflow

### DIFF
--- a/.github/workflows/reusable-image-scanning.yml
+++ b/.github/workflows/reusable-image-scanning.yml
@@ -1,0 +1,49 @@
+name: Reusable Image Scanning
+
+on:
+  workflow_call:
+    inputs:
+      dockerfile:
+        description: 'Path to Dockerfile'
+        required: false
+        type: string
+        default: 'Dockerfile'
+      context:
+        description: 'Docker build context'
+        required: false
+        type: string
+        default: '.'
+      severity:
+        description: 'Trivy severity levels to report'
+        required: false
+        type: string
+        default: 'CRITICAL,HIGH'
+
+jobs:
+  scan:
+    name: Build and scan image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build image
+        run: |
+          docker build -f ${{ inputs.dockerfile }} -t local/image:${{ github.sha }} ${{ inputs.context }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # 0.30.0
+        with:
+          image-ref: 'local/image:${{ github.sha }}'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: ${{ inputs.severity }}
+
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/caller-workflows/image-scanning.yml
+++ b/caller-workflows/image-scanning.yml
@@ -1,0 +1,36 @@
+name: Image Scanning
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/Dockerfile*'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/image-scanning.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/Dockerfile*'
+      - 'go.mod'
+      - 'go.sum'
+  schedule:
+    - cron: '0 8 * * 0'  # Weekly scan on Sunday
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  scan:
+    uses: kubestellar/infra/.github/workflows/reusable-image-scanning.yml@main
+    secrets: inherit
+    # Customize inputs per repo:
+    # with:
+    #   dockerfile: 'path/to/Dockerfile'
+    #   context: '.'


### PR DESCRIPTION
## Summary
Creates a reusable workflow for Trivy container vulnerability scanning.

## Reusable Workflow
`reusable-image-scanning.yml` with inputs:
- `dockerfile`: Path to Dockerfile (default: `Dockerfile`)
- `context`: Docker build context (default: `.`)
- `severity`: Trivy severity levels (default: `CRITICAL,HIGH`)

## Usage
Repos can call this with:
```yaml
jobs:
  scan:
    uses: kubestellar/infra/.github/workflows/reusable-image-scanning.yml@main
    with:
      dockerfile: 'path/to/Dockerfile'
```

## NOT Auto-Synced
This workflow is NOT added to auto-sync because:
- Not all repos have container images
- Some repos (galaxy, ui) have multiple images with custom matrix builds
- Repos that need it can manually adopt or be updated individually

## Repos with image scanning
- galaxy (3 components - needs custom matrix)
- kubeflex (single image)
- kubestellar (single image)
- ocm-status-addon (single image)
- ui (frontend + backend - needs custom)