### PR TITLE
🐛 Make labelsync resilient to deleted/private repos

### DIFF
--- a/prow/jobs/kubestellar/infra/infra-periodics.yaml
+++ b/prow/jobs/kubestellar/infra/infra-periodics.yaml
@@ -19,16 +19,17 @@ periodics:
         - -c
         - |
           # Sync repos one at a time to avoid parallel request hangs
-          # Exclude archived repos (ocm-transport-plugin)
-          REPOS=$(label_sync --config=/home/prow/go/src/github.com/kubestellar/infra/prow/labels.yaml --orgs=kubestellar --action=docs 2>/dev/null | grep "kubestellar/" | cut -d'/' -f2 | grep -v "ocm-transport-plugin" | sort -u || echo "")
+          # Get list of public, non-archived repos dynamically
+          REPOS=$(label_sync --config=/home/prow/go/src/github.com/kubestellar/infra/prow/labels.yaml --orgs=kubestellar --action=docs 2>/dev/null | grep "kubestellar/" | cut -d'/' -f2 | sort -u || echo "")
 
-          # If we can't get repo list dynamically, use known repos
-          # Note: ocm-transport-plugin is excluded because it's archived
+          # If we can't get repo list dynamically, use known public repos
+          # Excluded: core, homebrew-kubestellar (private), ocm-transport-plugin (archived)
           if [ -z "$REPOS" ]; then
-            REPOS=".github a2a community core docs galaxy helm homebrew-kubectl-multi homebrew-kubestellar infra kubectl-multi-plugin kubectl-rbac-flatten-plugin kubeflex kubestellar kubestellar-infrastructure kubestellar-killercoda ocm-status-addon presentations repo-template repo-template-go ui ui-plugins"
+            REPOS=".github a2a community docs galaxy helm homebrew-kubectl-multi infra kubectl-multi-plugin kubectl-rbac-flatten-plugin kubeflex kubestellar kubestellar-killercoda ocm-status-addon presentations repo-template repo-template-go ui ui-plugins"
           fi
 
           FAILED=""
+          SUCCESS_COUNT=0
           for repo in $REPOS; do
             echo "=== Syncing kubestellar/$repo ==="
             if label_sync \
@@ -39,18 +40,26 @@ periodics:
               --github-app-private-key-path=/etc/github/cert \
               --github-endpoint=https://api.github.com; then
               echo "SUCCESS: kubestellar/$repo"
+              SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
             else
-              echo "FAILED: kubestellar/$repo"
+              echo "FAILED: kubestellar/$repo (may be deleted, archived, or private)"
               FAILED="$FAILED $repo"
             fi
             echo ""
           done
 
+          echo "=== Summary ==="
+          echo "Successful: $SUCCESS_COUNT repos"
           if [ -n "$FAILED" ]; then
-            echo "Failed repos:$FAILED"
+            echo "Failed:$FAILED"
+            echo "Note: Failures may be due to deleted, archived, or private repos"
+          fi
+          # Only fail if ALL repos failed
+          if [ "$SUCCESS_COUNT" -eq 0 ]; then
+            echo "ERROR: All repos failed to sync"
             exit 1
           fi
-          echo "All repos synced successfully"
+          echo "Label sync completed"
         env:
         - name: GITHUB_APP_ID
           valueFrom:


### PR DESCRIPTION
## Summary
Fixes labelsync job failing due to `kubestellar-infrastructure` being deleted.

## Changes
1. **Removed deleted/private repos from fallback list:**
   - `kubestellar-infrastructure` (deleted)
   - `core` (private)
   - `homebrew-kubestellar` (private)

2. **Made job resilient to failures:**
   - Individual repo failures no longer fail the entire job
   - Only fails if ALL repos fail to sync
   - Adds summary showing success count and failed repos
   - Notes that failures may be due to deleted/archived/private repos

## Behavior
- Repos coming and going won't require config updates
- Job succeeds as long as at least one repo syncs successfully
- Clear logging of what failed and why