### PR TITLE
🌱 Enable rerun feature for Prow deck-public

### DIFF
--- a/clusters/prow/manifests/prow/01-deck-public.yaml
+++ b/clusters/prow/manifests/prow/01-deck-public.yaml
@@ -18,6 +18,7 @@ rules:
       - get
       - list
       - watch
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -95,7 +96,7 @@ spec:
             - --job-config-path=/etc/job-config
             - --spyglass=true
             - --s3-credentials-file=/etc/s3-credentials/service-account.json
-            - --rerun-creates-job=false
+            - --rerun-creates-job=true
             - --show-hidden=false
             - --github-token-path=/etc/github/token
             - --github-endpoint=http://ghproxy


### PR DESCRIPTION
## Summary
Enables the job rerun feature on the public Prow UI (prow2.kubestellar.io).

## Changes
1. Changed `--rerun-creates-job=false` to `--rerun-creates-job=true`
2. Added `create` verb to prowjobs RBAC for deck-public service account

## Usage
After this change, users can click "Rerun" on any job in the Prow UI to trigger a new run.