### PR TITLE
🌱 Add Claude Code configuration and slash commands

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,88 @@
+# KubeStellar Infrastructure Project
+
+## Repository Structure
+
+The kubestellar org has 20+ repos. Key ones:
+- **infra** - CI/CD infrastructure, Prow config, reusable workflows
+- **kubestellar** - Main project
+- **docs** - Documentation site (kubestellar.io/docs)
+- **kubeflex** - KubeFlex project
+- **ui** - UI project
+
+## Prow CI
+
+- **Dashboard**: https://prow2.kubestellar.io (public), https://prow2-private.kubestellar.io (private)
+- **Namespace**: `prow` for components, `test-pods` for jobs
+- **Config files**:
+  - `/clusters/prow/manifests/prow/` - Kubernetes manifests
+  - `/prow/config.yaml` - Main Prow config (in infra repo configmap)
+  - `/prow/plugins.yaml` - Plugin config
+  - `/prow/jobs/` - Job definitions
+
+### Common Prow Operations
+```bash
+# Check job status
+oc get prowjobs -n prow --sort-by=.metadata.creationTimestamp | tail -20
+
+# View component logs
+oc logs -n prow deployment/deck-public
+oc logs -n prow deployment/hook
+oc logs -n prow deployment/tide
+
+# Trigger job manually (via Prow rerun)
+# Use the rerun button on prow2.kubestellar.io after logging in
+```
+
+## GitHub Actions & Workflows
+
+### Reusable Workflows (in infra repo)
+Located in `.github/workflows/reusable-*.yml`:
+- `reusable-greetings.yml` - Welcome messages
+- `reusable-feedback.yml` - Survey links
+- `reusable-label-helper.yml` - Slash commands for labels
+- `reusable-scorecard.yml` - OpenSSF scorecard
+- `reusable-stale.yml` - Stale issue management
+- `reusable-image-scanning.yml` - Trivy scanning
+
+### Sync Workflow
+`sync-workflows.yml` distributes caller workflows to all public, non-archived repos.
+Caller workflows are in `caller-workflows/` directory.
+
+### GitHub Actions Discipline
+All workflow action references must use commit hashes (not tags).
+- Managed via `.gha-reversemap.yml`
+- Update with `hack/gha-reversemap.sh update-action-version <action>`
+- Apply with `hack/gha-reversemap.sh apply-reversemap`
+
+## Labelsync
+
+Periodic job syncs labels across all repos using `/prow/labels.yaml`.
+- Dynamically discovers repos via GitHub API
+- Skips archived repos
+- Job: `ci-infra-prow-labelsync`
+
+## Common Tasks
+
+### Create PR across repos
+1. Clone repo to /tmp/ks-<reponame>
+2. Create branch, make changes
+3. Commit with DCO: `git commit -s`
+4. Push and create PR with emoji title
+
+### Check CI on PR
+```bash
+unset GITHUB_TOKEN && gh pr checks <number> --repo kubestellar/<repo>
+```
+
+### Merge PR
+```bash
+unset GITHUB_TOKEN && gh pr comment <number> --repo kubestellar/<repo> --body "/lgtm"
+unset GITHUB_TOKEN && gh pr comment <number> --repo kubestellar/<repo> --body "/approve"
+# Or force merge:
+unset GITHUB_TOKEN && gh pr merge <number> --repo kubestellar/<repo> --merge --admin
+```
+
+## Working Directories
+
+- Repos cloned to: `/tmp/ks-<reponame>`
+- Infra work: `/Users/andan02/ks-ci-fixes/infra`

--- a/.claude/commands/check-pr.md
+++ b/.claude/commands/check-pr.md
@@ -1,0 +1,38 @@
+# Check PR CI Status & Comments
+
+Check CI status and review comments for a PR, then address any issues.
+
+## Arguments
+- $ARGUMENTS: repo/number (e.g., "kubestellar/3655" or "docs/640")
+
+## Steps
+
+### 1. Check CI Status
+```bash
+unset GITHUB_TOKEN && gh pr checks <number> --repo kubestellar/<repo>
+```
+
+### 2. Fix CI Failures
+- **DCO fails**: Amend commit with `-s` flag and force push
+- **PR Title fails**: Update title with emoji prefix (✨🐛📖📝⚠️🌱)
+- **Tests fail**: Investigate and fix code issues
+
+### 3. Review Comments
+```bash
+unset GITHUB_TOKEN && gh pr view <number> --repo kubestellar/<repo> --comments
+```
+
+### 4. Address Reviewer Feedback
+For each comment from copilot, reviewers, or bots:
+1. Read and understand the feedback
+2. Make necessary code changes
+3. Commit with DCO sign-off
+4. Reply to comment explaining how it was addressed
+
+### 5. Re-check Status
+After all fixes, verify CI passes:
+```bash
+unset GITHUB_TOKEN && gh pr checks <number> --repo kubestellar/<repo>
+```
+
+Report summary of what was fixed and current status.

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,36 @@
+# Create PR
+
+Create a PR with proper DCO sign-off and emoji title.
+
+## Arguments
+- $ARGUMENTS: Description of what to create (will prompt for details if needed)
+
+## Requirements (MUST FOLLOW)
+1. **DCO**: All commits MUST be signed with `-s` flag
+2. **Title**: MUST start with emoji (✨ feature | 🐛 bug | 📖 docs | 🌱 other)
+3. **Body**: Include Summary, Related issues, Test plan sections
+
+## Steps
+
+1. Determine target repo and branch
+2. Make code changes
+3. Stage and commit with DCO: `git add . && git commit -s -m "message"`
+4. Push branch: `git push -u origin <branch>`
+5. Create PR with proper title:
+```bash
+unset GITHUB_TOKEN && gh pr create --title "🐛 Fix description" --body "$(cat <<'EOF'
+## Summary
+- Brief description
+
+## Related issue(s)
+Fixes #
+
+## Test plan
+- [ ] Test item
+
+---
+Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+6. Run /check-pr to verify CI passes

--- a/.claude/commands/dependabot-prs.md
+++ b/.claude/commands/dependabot-prs.md
@@ -1,0 +1,58 @@
+# Dependabot PRs
+
+Check and manage dependabot PRs across kubestellar repos.
+
+## Arguments
+- $ARGUMENTS: Optional action (check, merge, close-conflicts)
+
+## Steps
+
+### 1. Check all repos for dependabot PRs
+```bash
+for repo in kubestellar kubeflex ui docs infra ocm-status-addon; do
+  echo "=== kubestellar/$repo ==="
+  unset GITHUB_TOKEN && gh pr list --repo kubestellar/$repo --author dependabot --state open 2>/dev/null || echo "No access or no PRs"
+done
+```
+
+### 2. For each Go dependency PR, check for vulnerabilities
+
+Clone the repo and checkout the PR branch:
+```bash
+cd /tmp && rm -rf ks-<repo> && git clone https://github.com/kubestellar/<repo>.git ks-<repo>
+cd /tmp/ks-<repo> && gh pr checkout <number>
+```
+
+Run vulnerability check:
+```bash
+# Install if needed: go install golang.org/x/vuln/cmd/govulncheck@latest
+govulncheck ./...
+```
+
+If vulnerabilities found:
+- Check if the dependabot update fixes them
+- If new vulnerabilities introduced, do NOT merge
+- Comment on PR with findings
+
+### 3. For each PR found:
+1. Check CI status
+2. Run govulncheck (for Go repos)
+3. If passing, no conflicts, no new vulns: merge with `/lgtm` and `/approve`
+4. If conflicting: close (will be recreated by dependabot)
+5. If new vulnerabilities: comment and do not merge
+
+### Merge command
+```bash
+unset GITHUB_TOKEN && gh pr comment <number> --repo kubestellar/<repo> --body "/lgtm"
+unset GITHUB_TOKEN && gh pr comment <number> --repo kubestellar/<repo> --body "/approve"
+```
+
+### Close conflicting PRs
+```bash
+unset GITHUB_TOKEN && gh pr close <number> --repo kubestellar/<repo> --comment "Closing due to conflicts. Dependabot will recreate."
+```
+
+### Other vulnerability tools (optional)
+- **npm audit** - For JavaScript/TypeScript repos (ui, docs)
+- **trivy** - Container image scanning
+- **snyk** - Multi-language vulnerability scanning

--- a/.claude/commands/merge-pr.md
+++ b/.claude/commands/merge-pr.md
@@ -1,0 +1,16 @@
+# Merge PR
+
+Add lgtm/approve labels and merge a PR.
+
+## Arguments
+- $ARGUMENTS: repo/number (e.g., "kubestellar/3655" or "docs/640")
+
+## Steps
+
+1. Parse repo and PR number from arguments
+2. Add lgtm: `unset GITHUB_TOKEN && gh pr comment <number> --repo kubestellar/<repo> --body "/lgtm"`
+3. Add approve: `unset GITHUB_TOKEN && gh pr comment <number> --repo kubestellar/<repo> --body "/approve"`
+4. Wait 15 seconds for labels to be applied
+5. Check if mergeable: `unset GITHUB_TOKEN && gh pr checks <number> --repo kubestellar/<repo> | grep tide`
+6. If still blocked, force merge: `unset GITHUB_TOKEN && gh pr merge <number> --repo kubestellar/<repo> --merge --admin`
+7. Verify merged status

--- a/.claude/commands/prow-status.md
+++ b/.claude/commands/prow-status.md
@@ -1,0 +1,29 @@
+# Prow Status
+
+Check Prow component health and recent job status.
+
+## Steps
+
+1. Check Prow pods:
+```bash
+oc get pods -n prow
+```
+
+2. Check recent prowjobs:
+```bash
+oc get prowjobs -n prow --sort-by=.metadata.creationTimestamp | tail -15
+```
+
+3. Check for failed jobs:
+```bash
+oc get prowjobs -n prow --field-selector=status.state=failure --sort-by=.metadata.creationTimestamp | tail -10
+```
+
+4. If issues found, check component logs:
+```bash
+oc logs -n prow deployment/deck-public --tail=50
+oc logs -n prow deployment/hook --tail=50
+oc logs -n prow deployment/tide --tail=50
+```
+
+5. Report summary of Prow health and any issues


### PR DESCRIPTION
## Summary
Adds project-specific Claude Code configuration for kubestellar infra work:

**CLAUDE.md** - Project context including:
- Repository structure (20+ kubestellar repos)
- Prow CI details (URLs, namespaces, config locations)
- GitHub Actions workflow info
- Common commands and patterns

**Slash Commands:**
- `/check-pr` - Check CI status, review comments, fix issues
- `/create-pr` - Create PR with proper DCO sign-off and emoji title
- `/merge-pr` - Add lgtm/approve labels and merge
- `/prow-status` - Check Prow component health
- `/dependabot-prs` - Manage dependabot PRs with govulncheck

## Related issue(s)
N/A - Developer tooling improvement

## Test plan
- [x] Commands created and tested during session

---
Generated with [Claude Code](https://claude.com/claude-code)