### PR TITLE
🐛 fix: rename github-token volume to avoid duplicate with decoration

### DIFF
--- a/prow/jobs/kubestellar/infra/infra-periodics.yaml
+++ b/prow/jobs/kubestellar/infra/infra-periodics.yaml
@@ -82,11 +82,11 @@ periodics:
               name: github-token
               key: appid
         volumeMounts:
-        - name: github-token
+        - name: github-app-key
           mountPath: /etc/github
           readOnly: true
       volumes:
-      - name: github-token
+      - name: github-app-key
         secret:
           secretName: github-token
 
@@ -109,10 +109,10 @@ periodics:
         args:
         - --config=/home/prow/go/src/github.com/kubestellar/infra/prow/autobump-config.yaml
         volumeMounts:
-        - name: github-token
+        - name: github-app-key
           mountPath: /etc/github-token
           readOnly: true
       volumes:
-      - name: github-token
+      - name: github-app-key
         secret:
           secretName: github-token


### PR DESCRIPTION
## Summary

Fixes the labelsync job failure caused by duplicate volume name.

**Error:**
```
Pod is invalid: spec.volumes[4].name: Duplicate value: "github-token"
```

**Root cause:** Prow's `default_decoration_config` already mounts a volume named `github-token` via `github_app_private_key_secret`. The explicit volume definition in the job configs caused a duplicate.

**Fix:** Renamed the explicit volume from `github-token` to `github-app-key` to avoid the conflict.

## Test Plan

- labelsync job should succeed after this fix is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)