### PR TITLE
✨ Add stale-exempt to default exempt labels

### DIFF
--- a/.github/workflows/reusable-stale.yml
+++ b/.github/workflows/reusable-stale.yml
@@ -17,7 +17,7 @@ on:
         description: 'Comma-separated labels exempt from stale'
         required: false
         type: string
-        default: 'security,bug,enhancement,good first issue,help wanted,hacktober-fest,lifecycle/frozen'
+        default: 'security,bug,enhancement,good first issue,help wanted,hacktober-fest,lifecycle/frozen,stale-exempt'
 
 jobs:
   stale:


### PR DESCRIPTION
### Description
Added `stale-exempt` label to the default exempt labels list in the reusable stale workflow. This allows repositories using this workflow to prevent important long-term issues from being automatically marked as stale and closed by applying the `stale-exempt` label.

### Related Issue
Fixes #98
Resolves kubestellar/kubestellar#3430

### Changes Made
- [x] Updated `exempt_labels` default value to include `stale-exempt`
- [x] Maintained proper YAML indentation and formatting

### Checklist
Please ensure the following before submitting your PR:
- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)
N/A - Configuration change only

### Additional Notes
This change affects all repositories using this reusable workflow. Issues labeled with `stale-exempt` will now be automatically excluded from stale marking and auto-closure across all consuming repositories.