### PR TITLE
✨ Add automatic PR comment when title verification fails

### DIFF
--- a/.github/workflows/reusable-pr-verify-title.yml
+++ b/.github/workflows/reusable-pr-verify-title.yml
@@ -3,6 +3,10 @@ name: Reusable PR Title Verifier
 on:
   workflow_call:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -12,6 +16,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Validate PR Title Format
+        id: validate
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
@@ -19,6 +24,7 @@ jobs:
 
           if [ -z "${TITLE}" ]; then
             echo "Error: PR title cannot be empty."
+            echo "error=empty" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
@@ -34,7 +40,75 @@ jobs:
             echo "🌱 (indicates Infra/Tests/Other)"
             echo -n "Your title's first character is, in hex: "
             python3 -c "import os; print('%x' % ord(os.environ['TITLE'][0]))"
+            echo "error=missing_emoji" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
           printf "PR title is valid: '%q'\n" "$TITLE"
+
+      - name: Comment on PR with title requirements
+        if: failure()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          script: |
+            const title = process.env.TITLE;
+            const body = `## ❌ PR Title Verification Failed
+
+            Your PR title does not follow the required format.
+
+            **Current title:** \`${title}\`
+
+            ### Required Format
+            PR titles must start with one of these emoji prefixes:
+
+            | Emoji | Meaning |
+            |-------|---------|
+            | ⚠️ | Breaking change |
+            | ✨ | Non-breaking feature |
+            | 🐛 | Patch fix / Bug fix |
+            | 📖 | Documentation |
+            | 🚀 | Release |
+            | 🌱 | Infra/Tests/Other |
+
+            ### How to Fix
+            Edit your PR title to start with the appropriate emoji. For example:
+            - \`✨ Add new feature for user authentication\`
+            - \`🐛 Fix crash when loading empty config\`
+            - \`📖 Update installation guide\`
+
+            You can edit the title by clicking the **Edit** button next to your PR title.
+
+            ---
+            *This comment was automatically posted by the PR Title Verifier workflow.*`;
+
+            // Check if we already commented to avoid duplicates
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const botComment = comments.data.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('PR Title Verification Failed')
+            );
+
+            if (botComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body
+              });
+            }
+        env:
+          TITLE: ${{ github.event.pull_request.title }}

--- a/caller-workflows/pr-verify-title.yml
+++ b/caller-workflows/pr-verify-title.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   verify:


### PR DESCRIPTION
## Summary
- When PR title verification fails, automatically post a helpful comment explaining the required format
- Prevents duplicate comments by updating existing bot comment if one exists
- Reduces maintainer burden of manually explaining emoji prefix requirements to contributors

## Changes
- `.github/workflows/reusable-pr-verify-title.yml`: Added comment step that runs on failure
- `caller-workflows/pr-verify-title.yml`: Added `pull-requests: write` permission

## Test plan
- [ ] Create a test PR with an invalid title (no emoji prefix)
- [ ] Verify the workflow posts a helpful comment
- [ ] Edit the PR title to still be invalid, verify comment is updated (not duplicated)
- [ ] Fix the PR title, verify workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)