### PR TITLE
✨ Bump Go 1.25 builder to 1.25.9 and add Go 1.26 builder

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -67,4 +67,26 @@ presubmits:
             requests:
               memory: 1Gi
               cpu: 1
-              
+
+  - name: pull-infra-images-1.26-build
+    decorate: true
+    clone_uri: "https://github.com/kubestellar/infra.git"
+    run_if_changed: '^images/build/go-1.26'
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/containers/buildah:v1.42.2
+          command:
+            - images/build/hack/build-image.sh
+            - go-1.26
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          env:
+            - name: DRY_RUN
+              value: '1'
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 1

--- a/images/build/go-1.26/Dockerfile
+++ b/images/build/go-1.26/Dockerfile
@@ -1,0 +1,67 @@
+ARG GO_VERSION
+
+FROM docker.io/library/golang:${GO_VERSION} AS download
+
+    # the Kubernetes version that is used to determine which kubectl to install.
+ENV KUBECTL_VERSION=1.34.6 \
+    # the kind version installed into this image.
+    # https://github.com/kubernetes-sigs/kind/releases
+    KIND_VERSION=0.31.0 \
+    # the Helm version installed into this image.
+    # https://github.com/helm/helm/releases
+    HELM_VERSION=3.17.4 \
+    # the kubeconform version installed into this image.
+    # https://github.com/yannh/kubeconform/releases
+    KUBECONFORM_VERSION=0.6.7
+
+WORKDIR /tmp
+
+RUN curl --fail -L https://get.helm.sh/helm-v${HELM_VERSION}-linux-$(dpkg --print-architecture).tar.gz | tar -xzO linux-$(dpkg --print-architecture)/helm > helm && \
+    chmod +x helm && \
+    ./helm version --short
+
+RUN curl --fail -Lo kubectl https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/$(dpkg --print-architecture)/kubectl && \
+    chmod +x kubectl && \
+    ./kubectl version --client
+
+RUN curl --fail -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-$(dpkg --print-architecture) && \
+    chmod +x kind && \
+    ./kind version
+
+RUN curl --fail -L https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-$(dpkg --print-architecture).tar.gz | tar -xzO kubeconform > kubeconform && \
+    chmod +x kubeconform && \
+    ./kubeconform -v
+
+FROM docker.io/library/golang:${GO_VERSION}
+
+# this is used by docker as data root
+VOLUME /docker-graph
+
+COPY --from=download /tmp/kubectl /usr/local/bin/
+COPY --from=download /tmp/kind /usr/local/bin/
+COPY --from=download /tmp/helm /usr/local/bin/
+COPY --from=download /tmp/kubeconform /usr/local/bin/
+
+COPY start-docker.sh /usr/local/bin/
+# this pre-loads the kindest/node image so it can be loaded via docker
+# when starting a container based on this image
+COPY kindest.tar /kindest.tar
+
+RUN apt-get update && \
+    apt-get install -y \
+        git \
+        curl \
+        jq \
+        buildah \
+    && rm -rf /var/lib/apt/lists/*
+
+# install Docker (and socat for tunneling the docker registry later)
+RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | gpg --dearmor > /usr/share/keyrings/docker.com.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.com.gpg] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends docker-ce=5:28.5.* socat && \
+    sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker && \
+    sed -i 's/ulimit -Hn/#ulimit -Hn/g' /etc/init.d/docker && \
+    mkdir -p /etc/docker && \
+    echo '{"data-root":"/docker-graph"}' | jq '.' > /etc/docker/daemon.json && \
+    rm -rf /var/lib/apt/lists/*

--- a/images/build/go-1.26/env
+++ b/images/build/go-1.26/env
@@ -1,7 +1,7 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.25.9-1
+BUILD_IMAGE_TAG=1.26.2-1
 # the Go version used for the images.
-GO_VERSION=1.25.9
+GO_VERSION=1.26.2
 # the kindest image that matches the kind version above
-KINDEST_IMAGE=kindest/node:v1.33.7@sha256:d26ef333bdb2cbe9862a0f7c3803ecc7b4303d8cea8e814b481b09949d353040
+KINDEST_IMAGE=kindest/node:v1.35.1@sha256:05d7bcdefbda08b4e038f644c4df690cdac3fba8b06f8289f30e10026720a1ab

--- a/images/build/go-1.26/start-docker.sh
+++ b/images/build/go-1.26/start-docker.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+## This script should be called by all containers that
+## want to use docker-in-docker. This ensures a consistent
+## setup instead of homegrown custom hacks in each
+## repository.
+## It is safe to call this multiple times, only the first
+## invocation will start the daemon.
+
+set -euo pipefail
+
+retry() {
+  # Works only with bash but doesn't fail on other shells
+  set +e
+  actual_retry $@
+  rc=$?
+  set -e
+  return $rc
+}
+
+# We use an extra wrapping to write junit and have a timer
+actual_retry() {
+  retries=$1
+  shift
+
+  count=0
+  delay=1
+  until "$@"; do
+    rc=$?
+    count=$((count + 1))
+    if [ $count -lt "$retries" ]; then
+      echo "Retry $count/$retries exited $rc, retrying in $delay seconds..." > /dev/stderr
+      sleep $delay
+    else
+      echo "Retry $count/$retries exited $rc, no more retries left." > /dev/stderr
+      return $rc
+    fi
+    delay=$((delay + 1))
+  done
+  return 0
+}
+
+echodate() {
+  # do not use -Is to keep this compatible with macOS
+  echo "[$(date +%Y-%m-%dT%H:%M:%S%:z)]" "$@"
+}
+
+# does Docker already run?
+if docker stats --no-stream > /dev/null 2>&1; then
+  exit 0
+fi
+
+echodate "Starting Docker"
+
+# This is needed so Docker-In-Docker still works when the peer doesn't allow ICMP packages and hence path mtu discovery cant work
+# Most notably, pmtud doesn't work with the hoster of the Alpine package mirror, fastly, causing dind builds of alpine to hang
+# forever. Upstream issue: See https://github.com/gliderlabs/docker-alpine/issues/307#issuecomment-427246497
+echodate "Configuring iptables"
+iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+
+# Configure a registry mirror. This will help only the `docker build` commands during
+# regular Prow job, but will not affect any kind clusters that are started from within
+# Prow jobs.
+registryMirror="${DOCKER_REGISTRY_MIRROR:-}"
+if [ -n "$registryMirror" ]; then
+  echodate "Configuring registry mirror"
+  jq --arg mirror "$registryMirror" '."registry-mirrors" = [$mirror]' /etc/docker/daemon.json > /etc/docker/daemon.new.json
+  mv /etc/docker/daemon.new.json /etc/docker/daemon.json
+fi
+
+mtu=${DOCKER_MTU:-0}
+if [[ $mtu -gt 0 ]]; then
+  echodate "Configuring MTU"
+  jq --argjson mtu $mtu '.mtu = $mtu' /etc/docker/daemon.json > /etc/docker/daemon.new.json
+  mv /etc/docker/daemon.new.json /etc/docker/daemon.json
+fi
+
+# start Docker daemon
+service docker start
+
+# wait for Docker to start
+retry 5 docker stats --no-stream
+echodate "Docker became ready"

--- a/prow/jobs/kubestellar/infra/infra-postsubmits.yaml
+++ b/prow/jobs/kubestellar/infra/infra-postsubmits.yaml
@@ -110,4 +110,26 @@ postsubmits:
               requests:
                 cpu: 2
                 memory: 3Gi
-                
+
+    - name: post-infra-publish-images-1.26-build
+      decorate: true
+      clone_uri: "https://github.com/kubestellar/infra.git"
+      cluster: prow # GHCR credentials are only available here
+      labels:
+        preset-ghcr-credentials: "true"
+      branches:
+        - ^main$
+      run_if_changed: '^images/build/go-1.26'
+      spec:
+        containers:
+          - image: quay.io/containers/buildah:v1.42.2
+            command:
+              - images/build/hack/build-image.sh
+              - go-1.26
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 2
+                memory: 3Gi


### PR DESCRIPTION
## Summary
- Bump go-1.25 builder from Go 1.25.5 to 1.25.9, kindest/node from v1.33.0 to v1.33.7
- Add new go-1.26 builder with Go 1.26.2, kindest/node v1.35.1
- Add presubmit and postsubmit Prow jobs for go-1.26 using buildah v1.42.2

## Test plan
- [ ] Presubmit `pull-infra-images-1.25-build` passes (validates go-1.25 image build)
- [ ] Presubmit `pull-infra-images-1.26-build` passes (validates go-1.26 image build)
- [ ] After merge, postsubmit jobs publish updated images to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)