### PR TITLE
fix: allow kubestellar-hive app to push to docs main

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -200,7 +200,8 @@ branch-protection:
           required_status_checks:
             contexts: []
           restrictions:
-            users: []
+            users:
+              - kubestellar-hive[bot]
             teams:
               - kubestellar/kubestellar-docs-maintainers
               - kubestellar/kubestellar-ui-admins


### PR DESCRIPTION
## Summary
- Adds `kubestellar-hive[bot]` to the branch protection `restrictions.users` for `kubestellar/docs`
- This allows the hive dashboard snapshot publisher to push directly to main without being blocked by branch protection restrictions
- The branchprotector CronJob was resetting manual changes every 6 hours — this makes the fix permanent in config

## Context
The hive dashboard snapshot at kubestellar.io/live/hive stopped updating because the app couldn't push to docs main. The branchprotector enforces restrictions that only allow listed teams/users to push, and the hive app wasn't listed.