### PR TITLE
bump Go builder images to 1.26.3 and 1.25.10

### DIFF
--- a/images/build/go-1.25/env
+++ b/images/build/go-1.25/env
@@ -1,7 +1,7 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.25.9-1
+BUILD_IMAGE_TAG=1.25.10-1
 # the Go version used for the images.
-GO_VERSION=1.25.9
+GO_VERSION=1.25.10
 # the kindest image that matches the kind version above
 KINDEST_IMAGE=kindest/node:v1.33.7@sha256:d26ef333bdb2cbe9862a0f7c3803ecc7b4303d8cea8e814b481b09949d353040

--- a/images/build/go-1.26/env
+++ b/images/build/go-1.26/env
@@ -1,7 +1,7 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.26.2-1
+BUILD_IMAGE_TAG=1.26.3-1
 # the Go version used for the images.
-GO_VERSION=1.26.2
+GO_VERSION=1.26.3
 # the kindest image that matches the kind version above
 KINDEST_IMAGE=kindest/node:v1.35.1@sha256:05d7bcdefbda08b4e038f644c4df690cdac3fba8b06f8289f30e10026720a1ab


### PR DESCRIPTION
## Summary
- Bump `images/build/go-1.26` to Go 1.26.3 (from 1.26.2)
- Bump `images/build/go-1.25` to Go 1.25.10 (from 1.25.9)
- Reset `BUILD_IMAGE_TAG` suffix to `-1` for each new Go version

## Test plan
- [ ] Builder images build successfully for go-1.26 and go-1.25