### PR TITLE
fix: remove docs repo from branchprotector enforcement

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -195,14 +195,6 @@ branch-protection:
           include:
             - "^main$"
             - "^release-.+$"
-        docs:  # Added docs repository without DCO check
-          protect: true
-          required_status_checks:
-            contexts: []
-          include:
-            - "^main$"
-            - "^dev$"
-            - "^release-.+$"
 
 # decorate_all_jobs: true
 


### PR DESCRIPTION
## Summary

- Remove `docs` block from `branch-protection.orgs.kubestellar.repos` in Prow config
- The branchprotector CronJob runs every 6 hours and was re-adding `required_status_checks` to `kubestellar/docs`, overwriting manual branch protection settings
- The docs repo does not need Prow-managed branch protection rules

## Test plan

- [ ] Verify branchprotector no longer touches `kubestellar/docs` after next CronJob run (~6h cycle)
- [ ] Confirm manual branch protection settings on docs repo persist