### PR TITLE
diag: touch go-1.25/env to test postsubmit trigger (#140)

### DIFF
--- a/images/build/go-1.25/env
+++ b/images/build/go-1.25/env
@@ -1,5 +1,6 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
+# Diagnostic touch for kubestellar/infra#140 to test postsubmit triggering.
 BUILD_IMAGE_TAG=1.25.10-1
 # the Go version used for the images.
 GO_VERSION=1.25.10


### PR DESCRIPTION
## Summary
- Diagnostic-only PR for #140 (builder image updates being ignored).
- Touches `images/build/go-1.25/env` with a single comment line to provoke a push event matching `^images/build/go-1.25` so we can observe whether Prow's `hook` creates the `post-infra-publish-images-1.25-build` postsubmit on merge.

## Plan
1. Watch `kubectl -n prow logs -f deployment/hook` for the push event after merge.
2. Watch `kubectl -n prow get prowjobs -w` for a `post-infra-publish-images-1.25-build` to appear.
3. If the postsubmit fires, the side-effect is publishing the (currently missing) `ghcr.io/kubestellar/infra/build:1.25.10-1` image.
4. If it does not fire, the live hook log will show why.

No code-path changes; reverts to a no-op once #140 is resolved.