### PR TITLE
Change infra postsubmits to use default cluster instead of prow

### DIFF
--- a/prow/jobs/kubestellar/infra/infra-postsubmits.yaml
+++ b/prow/jobs/kubestellar/infra/infra-postsubmits.yaml
@@ -4,7 +4,7 @@ postsubmits:
       max_concurrency: 1
       run_if_changed: "clusters/prow/"
       decorate: true
-      cluster: prow
+      cluster: default
       clone_uri: "https://github.com/kubestellar/infra.git"
       labels:
         preset-prow-kubeconfig: "true"
@@ -19,13 +19,13 @@ postsubmits:
               - name: KUBECONFIG
                 value: /etc/prow/kubeconfig/kubeconfig
               - name: KUBE_CONTEXT
-                value: prow
+                value: default
 
     - name: post-infra-deploy-build-cluster
       max_concurrency: 1
       run_if_changed: "clusters/build/"
       decorate: true
-      cluster: prow
+      cluster: default
       clone_uri: "https://github.com/kubestellar/infra.git"
       labels:
         preset-prow-kubeconfig: "true"
@@ -45,7 +45,7 @@ postsubmits:
     - name: post-infra-publish-images-1.23-build
       decorate: true
       clone_uri: "https://github.com/kubestellar/infra.git"
-      cluster: prow # GHCR credentials are only available here
+      cluster: default
       labels:
         preset-ghcr-credentials: "true"
       branches:
@@ -68,7 +68,7 @@ postsubmits:
     - name: post-infra-publish-images-1.24-build
       decorate: true
       clone_uri: "https://github.com/kubestellar/infra.git"
-      cluster: prow # GHCR credentials are only available here
+      cluster: default
       labels:
         preset-ghcr-credentials: "true"
       branches:
@@ -91,7 +91,7 @@ postsubmits:
     - name: post-infra-publish-images-1.25-build
       decorate: true
       clone_uri: "https://github.com/kubestellar/infra.git"
-      cluster: prow # GHCR credentials are only available here
+      cluster: default
       labels:
         preset-ghcr-credentials: "true"
       branches:
@@ -114,7 +114,7 @@ postsubmits:
     - name: post-infra-publish-images-1.26-build
       decorate: true
       clone_uri: "https://github.com/kubestellar/infra.git"
-      cluster: prow # GHCR credentials are only available here
+      cluster: default
       labels:
         preset-ghcr-credentials: "true"
       branches:


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

This PR changes the infra postsubmits (which were the only job prescriptions saying this) from specifying `cluster: prow` to specifying `cluster: default` (like everything else).

The Secret prow/kubeconfig now only has a context named "default", but present breakage (see Issue #140) and history suggest that it used to have a context named "prow".
Andy confirms that there is just one cluster.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

I hope that this addresses #140 .

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated `prow/jobs/kubestellar/infra/infra-postsubmits.yaml`

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
